### PR TITLE
docs(seo): enable tags plugin with browsable index page

### DIFF
--- a/archive/pre-seo/README.md
+++ b/archive/pre-seo/README.md
@@ -1,0 +1,285 @@
+# MegaDetector
+
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
+
+MegaDetector is one project in the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) ecosystem and is invoked through the [PyTorch Wildlife](https://github.com/microsoft/PytorchWildlife) framework. It is free, open-source, and available under permissive licenses.
+
+[![PyPI](https://img.shields.io/pypi/v/PytorchWildlife?color=limegreen)](https://pypi.org/project/PytorchWildlife)
+[![Downloads](https://static.pepy.tech/badge/pytorchwildlife)](https://pypi.org/project/PytorchWildlife)
+[![Python](https://img.shields.io/pypi/pyversions/PytorchWildlife)](https://pypi.org/project/PytorchWildlife)
+[![HuggingFace](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue)](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife)
+[![License](https://img.shields.io/pypi/l/PytorchWildlife)](https://github.com/microsoft/MegaDetector/blob/main/LICENSE)
+[![Discord](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=Discord)](https://discord.gg/TeEVxzaYtm)
+
+
+## Quick Start
+
+```bash
+pip install PytorchWildlife
+```
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+
+# Load MegaDetector V6 (weights download automatically)
+model = pw_detection.MegaDetectorV6()
+
+# Run on a single image
+results = model.single_image_detection("path/to/camera_trap_image.jpg")
+
+# Run on a folder of images
+results = model.batch_image_detection("path/to/image_folder/")
+```
+
+That's it. Three lines to detect animals in your camera-trap images.
+
+**Try it without installing anything:**
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
+
+
+## What Does MegaDetector Do?
+
+Camera traps generate millions of images, and the vast majority are empty frames triggered by wind or vegetation. Manually reviewing them is one of the biggest bottlenecks in wildlife research.
+
+MegaDetector solves this. It scans your images and draws bounding boxes around any animal — mammals, birds, reptiles, insects, and more. Each detection has a confidence score between 0 and 1. You set a threshold (typically 0.15–0.3), and anything above it is flagged. The output lets you sort images, filter blanks, or feed detected animals into a species classifier.
+
+MegaDetector is intentionally a **detector**, not a classifier. "Animal vs. background" generalizes across ecosystems far better than species identification. For species classification, pair MegaDetector with a downstream classifier — see [Species Classification](#species-classification) below.
+
+
+## MegaDetector V6
+
+The latest release focuses on **efficiency**, **modern architectures**, and **licensing flexibility** — **SMALLER, FASTER, BETTER**.
+
+### Highlights
+
+- **50x smaller**: The compact YOLOv10 variant has **2.3M parameters** — 2% of MegaDetector V5's 139.9M — with comparable accuracy
+- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR — pick the one that fits your hardware
+- **Permissive licenses**: MIT and Apache-2.0 options alongside AGPL-3.0
+- **Ongoing fine-tuning**: V6 models are continuously fine-tuned on newly collected public and private data to further improve generalization
+
+### Model Variants
+
+| Model | Params | Animal Recall | mAP50 | License |
+| --- | --- | --- | --- | --- |
+| MDV6-apa-rtdetr-e | 76M | 82.9% | 94.1% | Apache-2.0 |
+| MDV6-yolov10-e | 29.5M | 82.8% | 92.8% | AGPL-3.0 |
+| MDV6-yolov9-e | 58.1M | 82.1% | 88.6% | AGPL-3.0 |
+| MDV6-rtdetr-c | 31.9M | 81.6% | 89.9% | AGPL-3.0 |
+| MDV6-apa-rtdetr-c | 20M | 81.1% | 91.0% | Apache-2.0 |
+| MDV6-yolov9-c | 25.5M | 78.4% | 87.9% | AGPL-3.0 |
+| MDV6-yolov10-c | 2.3M | 76.8% | 87.2% | AGPL-3.0 |
+| MDV6-mit-yolov9-e | 51M | 76.1% | 71.5% | MIT |
+| MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
+
+Model names are standardized into **MDV6-Compact** and **MDV6-Extra** for the two model sizes within each architecture, reducing confusion across variants.
+
+**Which should I use?**
+- **Best accuracy**: MDV6-apa-rtdetr-e (82.9% recall, Apache-2.0)
+- **Best for laptops/edge**: MDV6-yolov10-c (2.3M params, runs on CPU)
+- **Best balance**: MDV6-yolov10-e (29.5M params, 82.8% recall)
+- **Need MIT license?**: MDV6-mit-yolov9-c
+
+```python
+# Load a specific variant
+from PytorchWildlife.models import detection as pw_detection
+
+model = pw_detection.MegaDetectorV6(version="MDV6-apa-rtdetr-e")
+```
+
+
+## Installation
+
+```bash
+pip install PytorchWildlife
+```
+
+**Requirements:**
+- Python 3.8+ (3.10+ recommended)
+- Optional: NVIDIA GPU with CUDA for 10–50x speedup
+
+**Conda users:**
+```bash
+conda create -n megadetector python=3.10 -y
+conda activate megadetector
+pip install PytorchWildlife
+```
+
+**GPU setup (if PyTorch didn't install with CUDA):**
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+```
+
+Full installation guide: [microsoft.github.io/MegaDetector/installation/](https://microsoft.github.io/MegaDetector/installation/)
+
+
+## Species Classification
+
+MegaDetector finds animals — it doesn't identify species. For species ID, run a two-stage pipeline:
+
+1. **MegaDetector** detects and localizes animals
+2. **A species classifier** identifies the species in each crop
+
+```python
+import supervision as sv
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+
+detector = pw_detection.MegaDetectorV6()
+classifier = pw_classification.AI4GAmazonRainforest()
+
+det_results = detector.single_image_detection("image.jpg")
+
+for xyxy in det_results["detections"].xyxy:
+    cropped = sv.crop_image(image=det_results["img"], xyxy=xyxy)
+    cls_result = classifier.single_image_classification(cropped)
+    print(f"Species: {cls_result['prediction']}")
+```
+
+**Available classifiers in PyTorch Wildlife:**
+
+| Classifier | Region | Classes | License |
+| --- | --- | --- | --- |
+| AI4G Amazon Rainforest | Amazon basin | 36 | MIT |
+| AI4G Snapshot Serengeti | East Africa | 10 | MIT |
+| AI4G Opossum | Galapagos | 2 | MIT |
+| DeepFaune Classifier | Europe | 34 | CC BY-SA 4.0 |
+| DFNE | Northeastern U.S. | 23 | CC0 1.0 |
+
+Google's [SpeciesNet](https://github.com/google/cameratrapai) is also designed to work with MegaDetector output and covers ~2,000 species globally.
+
+
+## Desktop and Web Interfaces
+
+### SPARROW Studio
+
+[SPARROW Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) is a unified desktop application by the AI for Good Lab built on PyTorch Wildlife:
+
+- Run MegaDetector and species classifiers through a graphical interface
+- Manage camera-trap data locally or in the cloud
+- Annotate, analyze, and visualize detection results
+- Supports bioacoustics and overhead wildlife imagery
+
+Windows installer: [Download from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1) (signed). Mac and Linux builds in progress.
+
+### AddaxAI (formerly EcoAssist)
+
+[AddaxAI](https://addaxdatascience.com/addaxai/) is a third-party desktop tool for running MegaDetector with batch processing, annotation, and results visualization. Windows, macOS, and Linux.
+
+### Hugging Face Space
+
+[Upload images and run MegaDetector in your browser](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — no installation required.
+
+
+## Part of the Biodiversity Ecosystem
+
+MegaDetector is one model in a larger open-source ecosystem from the AI for Good Lab. Each project lives in its own repository, with the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella tying them together.
+
+| Repo | Purpose |
+| --- | --- |
+| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
+| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework that hosts MegaDetector, species classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, DeepFaune), HerdNet, PW-Engine (a Rust-based inference core), and demo notebooks |
+| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in remote field locations |
+| [microsoft/MegaDetector-Acoustics](https://github.com/microsoft/MegaDetector-Acoustics) | Bioacoustic models for audio-based wildlife monitoring |
+| [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
+| [/SPARROW-Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | The desktop application that wraps it all in a graphical interface |
+
+MegaDetector is the entry point for most users. SPARROW Studio is the full platform. SPARROW is the field-hardened edge device.
+
+
+## Organizations Using MegaDetector
+
+MegaDetector is used by 80+ organizations across government agencies, universities, NGOs, and technology companies worldwide. A selection:
+
+**Government**: Arizona DEQ, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada (Banff), U.S. Fish & Wildlife Service (multiple refuges), National Park Service, Canadian Wildlife Service
+
+**Conservation NGOs**: The Nature Conservancy, Island Conservation, Wildlife Protection Solutions, Australian Wildlife Conservancy, RSPB, CPAWS, SPEA, Felidae Conservation Fund
+
+**Universities**: UCLA, University of Washington, UBC, University of Florida, University of Idaho, UNSW Sydney, Macquarie University, University of Saskatchewan, Washington State University, Bangor University, Tel Aviv University, TU Berlin, Wildlife Institute of India
+
+**Museums & Zoos**: American Museum of Natural History, Smithsonian, Woodland Park Zoo, San Diego Zoo Wildlife Alliance, Taronga Conservation Society
+
+**Platforms**: TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network, OCAPI, WildePod
+
+See the [full list](https://github.com/microsoft/PytorchWildlife#who-uses-megadetector) in the PyTorch Wildlife repository.
+
+
+## Performance
+
+| Hardware | Model | Approximate Speed |
+| --- | --- | --- |
+| NVIDIA RTX 3090 | MDV6-yolov10-c (2.3M) | ~100–200 images/sec |
+| NVIDIA RTX 3090 | MDV6-yolov10-e (29.5M) | ~30–60 images/sec |
+| Modern CPU (no GPU) | MDV6-yolov10-c (2.3M) | ~2–5 images/sec |
+| Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
+
+At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU with the compact model, about 3.9 days.
+
+Every V6 variant is faster than V5 (139.9M params). The compact V6 is 2% the size.
+
+
+## Version History
+
+| Version | Year | Architecture | Params | Notes |
+| --- | --- | --- | --- | --- |
+| **V6.0** (current) | 2024 | YOLOv9/v10, RT-DETR | 2.3M–76M | Multiple variants, MIT/Apache options |
+| V5.0 | 2022 | YOLOv5 | 139.9M | Two sub-versions (5a, 5b) |
+| V4.1 | 2020 | Faster R-CNN | — | Added vehicle class |
+| V3 | 2019 | Faster R-CNN | — | Added human class |
+| V2 | 2018 | Faster R-CNN | — | First public release |
+
+
+## MegaDetector V5 and Earlier
+
+For MegaDetectorV5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
+
+The original MegaDetector repository was primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a forked version at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which remains a valuable resource for the community.
+
+
+## Our Commitment
+
+At the core of our mission is the desire to create a harmonious space where conservation scientists from all over the globe can unite — to share, grow, and use datasets and deep learning architectures for wildlife conservation. We've been inspired by the potential and capabilities of MegaDetector, and we deeply value its contributions to the community. We remain committed to supporting, maintaining, and developing MegaDetector — ensuring its continued relevance, expansion, and utility.
+
+
+## Citing MegaDetector
+
+**PyTorch Wildlife (the framework):**
+```bibtex
+@misc{hernandez2024pytorchwildlife,
+      title={Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation},
+      author={Andres Hernandez and Zhongqi Miao and Luisa Vargas and Sara Beery and Rahul Dodhia and Juan Lavista},
+      year={2024},
+      eprint={2405.12930},
+      archivePrefix={arXiv},
+}
+```
+
+**MegaDetector (the original model):**
+```bibtex
+@misc{beery2019efficient,
+      title={Efficient Pipeline for Camera Trap Image Review},
+      author={Sara Beery and Dan Morris and Siyu Yang},
+      year={2019},
+      eprint={1907.06772},
+      archivePrefix={arXiv},
+}
+```
+
+You can also use GitHub's "Cite this repository" button in the sidebar.
+
+
+## Contributing
+
+MegaDetector's source code lives in this repository. To contribute code, file issues, or submit pull requests, head to [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues).
+
+For framework-level changes (PyTorch Wildlife API, classifiers, demo notebooks), see [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife). For ecosystem-wide questions, see the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
+
+For questions, feature requests, or to report how MegaDetector worked on your data:
+- **Email**: [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Discord**: [![Discord](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=Discord)](https://discord.gg/TeEVxzaYtm)
+- **GitHub Discussions**: [microsoft/Biodiversity/discussions](https://github.com/microsoft/Biodiversity/discussions)
+
+
+## License
+
+The MegaDetector code is released under the [MIT License](LICENSE). Individual model weights are released under MIT, Apache-2.0, or AGPL-3.0 — see the [Model Variants](#model-variants) table for per-variant licensing.

--- a/archive/pre-seo/docs/training_guide.md
+++ b/archive/pre-seo/docs/training_guide.md
@@ -1,0 +1,176 @@
+# MegaDetector Model Fine-tuning Guide
+
+This guide covers training and fine-tuning detection models for MegaDetector using the ultralytics framework. This module is designed to help both programmers and biologists train a detection model for animal identification. The output weights of this training process can be easily integrated with MegaDetector inference.
+
+## Installation
+
+Before you start, ensure you have Python installed on your machine. This project is developed using Python 3.10. If you're not sure how to install Python, you can find detailed instructions on the [official Python website](https://www.python.org/).
+
+To install the required libraries and dependencies, follow these steps:
+
+### Using pip and `requirements.txt`
+
+```bash
+pip install -r requirements.txt
+```
+
+### Using conda and `environment.yaml`
+
+Create and activate a Conda environment with Python 3.10:
+
+```bash
+conda env create -f environment.yaml
+conda activate PW_Finetuning_Detection
+```
+
+## Data Preparation
+
+### Data Structure
+
+The codebase is optimized for ease of use by non-technical users. For the code to function correctly, data should be organized as follows. Inside `data/`, create a subfolder `your_data/` including two subfolders: `images/` and `labels/`. The `images/` folder should have three subfolders named `test/`, `train/`, and `val/` for storing test, training, and validation images respectively. Similarly, the `labels/` folder should have subfolders `test/`, `train/`, and `val/` for the corresponding annotation files in txt format. Place a configuration file named `your_data.yaml` within the `data/` folder, alongside the `your_data/` folder.
+
+Example directory structure:
+
+```plaintext
+project_root/
+│
+└── data/
+   ├── your_data/
+   |    ├── images/
+   |    |    ├── test/
+   |    │    ├── train/
+   |    │    └── val/
+   |    └── labels/ 
+   |         ├── test/
+   |         ├── train/
+   |         └── val/
+   └── your_data.yaml
+```
+
+### Data Configuration File Structure
+
+To ensure the code works correctly, `your_data.yaml` file should be structured as follows. The `path` field should contain the relative path to your `your_data/` folder. The `train`, `val`, and `test` fields should point to the subdirectories within the `images/` folder where the training, validation, and test images are stored, respectively. For the classes, the `names` field should be a list where each class is assigned to a unique identifier number.
+
+Example `data.yaml`:
+
+```yaml
+path: path/to/your_data
+train: images/train
+val: images/val
+test: images/test
+
+nc: 2  # number of classes
+names: ['class_0', 'class_1']
+```
+
+### Annotations Structure
+
+The `.txt` files inside each folder of `./data/labels/` must be structured containing each object on a separate line, following the format: `class x_center y_center width height`. The coordinates for the bounding box should be normalized in the xywh format, with values ranging from 0 to 1.
+
+### Demo Data
+
+You can download some example [demo data](https://zenodo.org/records/15376499/files/demo_data_det.zip?download=1) to test the codebase. Before using the data, make sure to decompress the zip file following the [data directory structure](#data-structure), and check if the `data` and `test_data` entries in the [config file](../examples/config_training.yaml) are pointing to the data directory. The testing demo data also has an annotation example showing how the preferred annotation format looks like.
+
+## Detection Models Available for Fine-tuning
+
+Below you find the models that you can use for fine-tuning, along with their respective names to use in the configuration file.
+
+| Model | Name | License |
+|---|---|---|
+| MegaDetectorV6-Ultralytics-YoloV9-Compact | MDV6-yolov9-c | AGPL-3.0 |
+| MegaDetectorV6-Ultralytics-YoloV9-Extra | MDV6-yolov9-e | AGPL-3.0 |
+| MegaDetectorV6-Ultralytics-YoloV10-Compact | MDV6-yolov10-c | AGPL-3.0 |
+| MegaDetectorV6-Ultralytics-YoloV10-Extra | MDV6-yolov10-e | AGPL-3.0 |
+| MegaDetectorV6-Ultralytics-RtDetr-Compact | MDV6-rtdetr-c | AGPL-3.0 |
+
+## Configuration
+
+Before training your model, you need to configure the training and data parameters in the `config.yaml` file. Here's a brief explanation of the parameters to help both technical and non-technical users understand their purposes:
+
+### General Parameters
+
+- `model`: The type of model used (YOLO or RTDETR). Default: YOLO
+- `model_name`: The name of the model (see available names [here](#detection-models-available-for-fine-tuning)). Default: MDV6-yolov9-e
+- `data`: Path to the dataset configuration file. Default: ./data/data_example.yaml
+- `test_data`: Path to the test data directory. Default: ./data/data_example/images/test
+- `task`: The task to perform (train, validation or inference). Default: train
+- `exp_name`: The name of the experiment. Default: MDV6-yolov9e
+
+### Training Parameters
+
+- `epochs`: The total number of training epochs. Default: 20
+- `batch_size_train`: The batch size for training. Default: 16
+- `imgsz`: The image size. Default: 640
+- `device_train`: The device ID for training. Default: 0
+- `workers`: The number of workers. Default: 8
+- `optimizer`: The optimizer to use. Default: auto
+- `lr0`: The initial learning rate. Default: 0.01
+- `patience`: The number of epochs to wait before stopping without improvement. Default: 5
+- `save_period`: The period for saving the model. Default: 1
+- `val`: Boolean value indicating whether to perform validation while training. Default: True
+- `resume`: Boolean value indicating whether to resume training from weights. Default: False
+- `weights`: Path to the weights file to resume training. Default: None
+
+### Validation Parameters
+
+- `save_json`: Boolean value indicating whether to save results as JSON. Default: True
+- `plot`: Boolean value indicating whether to plot results. Default: True
+- `device_val`: The device ID for validation. Default: 0
+- `batch_size_val`: The batch size for validation. Default: 12
+
+## Usage
+
+After configuring your `config.yaml` file, you can start training your model by running:
+
+### Training
+
+```bash
+megadetector train --config ./config.yaml
+```
+
+Or using the Python API:
+
+```python
+from megadetector_ai.training import train
+train(config_path='./config.yaml')
+```
+
+### Validation
+
+```bash
+megadetector validate --config ./config.yaml
+```
+
+Or using the Python API:
+
+```python
+from megadetector_ai.training import validate
+validate(config_path='./config.yaml')
+```
+
+### Inference
+
+```bash
+megadetector inference --config ./config.yaml
+```
+
+Or using the Python API:
+
+```python
+from megadetector_ai.training import inference
+inference(config_path='./config.yaml')
+```
+
+This command will initiate the training process based on the parameters specified in `config.yaml`. Make sure to monitor the output for any errors or important information regarding the training progress.
+
+## Output
+
+Once training is complete, the output weights will be saved in the `./runs/` directory according to the task and experiment name you configured in the `config.yaml`. These weights can be used for inference with MegaDetector.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Support
+
+If you encounter any issues or have questions, please feel free to open an issue on the GitHub repository page. We aim to make this tool as accessible as possible and will gladly provide assistance.

--- a/archive/pre-seo/megadetector.md
+++ b/archive/pre-seo/megadetector.md
@@ -1,0 +1,53 @@
+# 🐾 MegaDetector
+
+> [!TIP]
+> MegaDetector now has its own home at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector). The full model zoo and PyTorch Wildlife framework live at [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife), with everything tied together under the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
+
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
+
+Our mission is to create a global community where conservation scientists can collaborate — sharing datasets and deep learning architectures for wildlife conservation. We're committed to supporting, maintaining, and advancing **MegaDetector** to ensure its continued **relevance, performance, and impact** for biodiversity research worldwide.
+
+
+## 🏎️ MegaDetectorV6: SMALLER, FASTER, BETTER!
+
+We have officially released our 6th version of MegaDetector, **MegaDetectorV6**. In the next generation of MegaDetector, we focused on computational efficiency, performance, modernizing of model architectures, and licensing. We have trained multiple new models using different model architectures that are optimized for performance and low-budget devices, including **YOLOv9**, **YOLOv10**, and **RT-DETR** for maximum user flexibility.
+
+For example, the **MegaDetectorV6-Ultralytics-YoloV10-Compact** (`MDV6-yolov10-c`) model has only ***2% of the parameters*** of the previous MegaDetectorV5 (2.3M vs. 139.9M) and still exhibits comparable performance on our validation datasets.
+
+To test the newest version of MegaDetector with all the existing functionalities, you can use our [Hugging Face interface](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) or simply load the model with **Pytorch-Wildlife**. The weights will be automatically downloaded:
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+detection_model = pw_detection.MegaDetectorV6()
+```
+
+We will continuously fine-tune our V6 models on newly collected public and private data to further improve generalization performance.
+
+> [!TIP]
+> All versions of MegaDetector and corresponding performance can be found in the [model zoo](https://microsoft.github.io/MegaDetector/model_zoo/megadetector/).
+
+> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model fits the project needs. To reduce potential confusion, we have also standardized the model names into **MDV6-Compact** and **MDV6-Extra** for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/PytorchWildlife/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/MegaDetector/demo_and_ui/demo_data/).
+
+
+## MegaDetectorV5 and Archive Repos
+
+For those interested in accessing the previous MegaDetector repository, which utilizes the same `MegaDetectorV5` model weights and was primarily developed by **Dan Morris** during his time at Microsoft, please visit the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`), or you can visit this [forked repository](https://github.com/agentmorris/MegaDetector/tree/main) that Dan Morris is currently actively maintaining.
+
+
+## Part of the Biodiversity Ecosystem
+
+MegaDetector is one project in a larger open-source ecosystem from the AI for Good Lab:
+
+| Repo | Purpose |
+| --- | --- |
+| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
+| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal detection in camera-trap imagery |
+| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
+| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
+| [microsoft/MegaDetector-Acoustics](https://github.com/microsoft/MegaDetector-Acoustics) | Bioacoustic models for audio-based wildlife monitoring |
+| [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
+| [/SPARROW-Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | The desktop application that wraps it all in a graphical interface |
+
+
+> [!TIP]
+> If you have any questions regarding MegaDetector and Pytorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PytorchWildlife)](https://discord.gg/TeEVxzaYtm)

--- a/archive/pre-seo/pyproject.toml
+++ b/archive/pre-seo/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "megadetector-ai"
+version = "0.1.0"
+description = "MegaDetector: AI-powered wildlife detection for camera trap images. A simplified interface to MegaDetector via PyTorch Wildlife."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+authors = [
+    {name = "Microsoft AI for Good Lab", email = "zhongqimiao@microsoft.com"},
+]
+keywords = [
+    "megadetector",
+    "camera traps",
+    "wildlife detection",
+    "animal detection",
+    "conservation",
+    "computer vision",
+    "object detection",
+    "deep learning",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+]
+dependencies = [
+    "PytorchWildlife",
+    "ultralytics>=8.0.0",
+    "munch>=2.0.0",
+    "wget>=3.0",
+    "PyYAML>=6.0",
+    "torch>=2.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/MegaDetector"
+Documentation = "https://microsoft.github.io/CameraTraps/"
+Repository = "https://github.com/microsoft/MegaDetector"
+"Source Code" = "https://github.com/microsoft/CameraTraps"
+"Bug Tracker" = "https://github.com/microsoft/CameraTraps/issues"
+
+[project.scripts]
+megadetector = "megadetector_ai.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,5 @@
+---
+description: "Browse all topics across the MegaDetector documentation."
+---
+
+# Tags

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Overview: index.md
     - Installation: installation.md
     - Model Zoo: model_zoo.md
+    - Tags: tags.md
   - Fine-tuning:
     - Training Guide: training_guide.md
   - Cite Us: cite.md
@@ -102,3 +103,5 @@ markdown_extensions:
 plugins:
   - search
   - meta
+  - tags:
+      tags_file: tags.md


### PR DESCRIPTION
## Summary
- Enables the Material for MkDocs `tags` plugin with `tags_file: tags.md` — all docs pages already have `tags:` front matter but without the plugin they were silently ignored (no chips on pages, no index)
- Creates `docs/tags.md` as the auto-populated tags index page
- Adds a Tags entry to the MegaDetector nav section

This mirrors the same fix applied to microsoft/Biodiversity (PR #640).

## Test plan
- [ ] Run `mkdocs serve` and navigate to `/tags/` — should list all tags with links to associated pages
- [ ] Click a tag (e.g., "MegaDetector") — should show all pages tagged with it
- [ ] Confirm tag chips appear on individual pages and link back to the index
- [ ] Confirm "Tags" appears in the nav under MegaDetector

🤖 Generated with [Claude Code](https://claude.com/claude-code)