### PR TITLE
Remove SPARROW-Studio cross-links; update ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,6 @@ Google's [SpeciesNet](https://github.com/google/cameratrapai) is also designed t
 
 ## Desktop and Web Interfaces
 
-### SPARROW Studio
-
-[SPARROW Studio](https://github.com/microsoft/SPARROW-Studio) is a unified desktop application by the AI for Good Lab built on PyTorch-Wildlife:
-
-- Run MegaDetector and species classifiers through a graphical interface
-- Manage camera-trap data locally or in the cloud
-- Annotate, analyze, and visualize detection results
-- Supports bioacoustics and overhead wildlife imagery
-
-Windows installer: [Download from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1) (signed). Mac and Linux builds in progress.
-
 ### AddaxAI (formerly EcoAssist)
 
 [AddaxAI](https://addaxdatascience.com/addaxai/) is a third-party desktop tool for running MegaDetector with batch processing, annotation, and results visualization. Windows, macOS, and Linux.
@@ -196,9 +185,7 @@ MegaDetector is one model in a larger open-source ecosystem from the AI for Good
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
-| [microsoft/SPARROW-Studio](https://github.com/microsoft/SPARROW-Studio) | The desktop application that wraps it all in a graphical interface |
-
-MegaDetector is the entry point for most users. SPARROW Studio is the full platform. SPARROW is the field-hardened edge device.
+MegaDetector is the entry point for most users. SPARROW is the field-hardened edge device.
 
 
 ## Organizations Using MegaDetector

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ Google's [SpeciesNet](https://github.com/google/cameratrapai) is also designed t
 
 ## Desktop and Web Interfaces
 
+### SPARROW Studio
+
+SPARROW Studio is a unified desktop application by the AI for Good Lab built on PyTorch-Wildlife:
+
+- Run MegaDetector and species classifiers through a graphical interface
+- Manage camera-trap data locally or in the cloud
+- Annotate, analyze, and visualize detection results
+- Supports bioacoustics and overhead wildlife imagery
+
+Windows installer: [Download from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1) (signed). Mac and Linux builds in progress.
+
 ### AddaxAI (formerly EcoAssist)
 
 [AddaxAI](https://addaxdatascience.com/addaxai/) is a third-party desktop tool for running MegaDetector with batch processing, annotation, and results visualization. Windows, macOS, and Linux.
@@ -185,7 +196,9 @@ MegaDetector is one model in a larger open-source ecosystem from the AI for Good
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
-MegaDetector is the entry point for most users. SPARROW is the field-hardened edge device.
+| SPARROW Studio | The desktop application that wraps it all in a graphical interface |
+
+MegaDetector is the entry point for most users. SPARROW Studio is the full platform. SPARROW is the field-hardened edge device.
 
 
 ## Organizations Using MegaDetector

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,7 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
+| SPARROW Studio | The desktop application that wraps it all in a graphical interface |
 
 > [!TIP]
 > If you have any questions regarding MegaDetector and PyTorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our Discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PyTorch-Wildlife)](https://discord.gg/TeEVxzaYtm)

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,6 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
-| [microsoft/SPARROW-Studio](https://github.com/microsoft/SPARROW-Studio) | The desktop application that wraps it all in a graphical interface |
 
 > [!TIP]
 > If you have any questions regarding MegaDetector and PyTorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our Discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PyTorch-Wildlife)](https://discord.gg/TeEVxzaYtm)

--- a/megadetector.md
+++ b/megadetector.md
@@ -54,6 +54,7 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
 | [microsoft/MegaDetector-Acoustics](https://github.com/microsoft/MegaDetector-Acoustics) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
+| SPARROW Studio | The desktop application that wraps it all in a graphical interface |
 
 
 > [!TIP]

--- a/megadetector.md
+++ b/megadetector.md
@@ -54,7 +54,6 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
 | [microsoft/MegaDetector-Acoustics](https://github.com/microsoft/MegaDetector-Acoustics) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
-| [SPARROW-Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | The desktop application that wraps it all in a graphical interface |
 
 
 > [!TIP]


### PR DESCRIPTION
## Summary

- Remove SPARROW-Studio from ecosystem tables in `README.md`, `megadetector.md`, and `docs/index.md` — the repo is not launching yet
- Remove the dedicated "SPARROW Studio" section from README (header, description, download link)
- Add MegaDetector-Sonar and MegaDetector-Classifier to ecosystem tables

## Test plan

- [ ] Verify no broken links remain pointing to SPARROW-Studio
- [ ] Confirm "Desktop and Web Interfaces" section renders cleanly with AddaxAI and Hugging Face Space remaining
- [ ] Confirm ecosystem table in "Part of the Biodiversity Ecosystem" section renders correctly