### PR TITLE
docs: add FAQ, camera-trap AI, and camera-trap software pages

### DIFF
--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -1,0 +1,104 @@
+---
+description: "Camera-trap AI explained — how machine learning automates wildlife monitoring, why AI-based detection matters for conservation, and how MegaDetector fits into the workflow."
+tags:
+  - camera trap AI
+  - wildlife AI
+  - camera trap machine learning
+  - automated wildlife monitoring
+  - conservation AI
+  - blank frame filtering
+  - camera trap image analysis
+---
+
+# Camera-Trap AI — What It Is and Why It Matters
+
+## The Camera-Trap Problem
+
+Camera traps are motion-triggered cameras deployed in the field to monitor wildlife. A single study may deploy hundreds of cameras over months or years, generating millions of images. The vast majority of those images are empty — triggered by wind, falling leaves, or temperature fluctuations rather than animals.
+
+Manually reviewing millions of images is one of the biggest bottlenecks in wildlife research. A trained reviewer can process a few hundred images per hour; a million-image dataset requires weeks of focused effort before any analysis can begin. This review burden limits how much data researchers can realistically collect and delays conservation decisions that depend on timely species counts, presence/absence data, and behavioral observations.
+
+
+## What Camera-Trap AI Does
+
+AI-based tools automate the most time-consuming parts of image review:
+
+**Blank-frame filtering** removes images with no animals before human review begins. In practice, 70–95% of camera-trap images are blank. Filtering them out automatically compresses the review queue by an order of magnitude.
+
+**Detection** draws bounding boxes around animals in images that contain them, so reviewers focus on the animal rather than scanning the full frame. Detection also quantifies *where* in the frame an animal appears and how confident the model is.
+
+**Classification** identifies the species (or group) within a detected bounding box. Classification is typically done as a second step after detection, because a detector that generalizes across ecosystems is easier to build and maintain than a species classifier that must be retrained for every new region.
+
+**Tracking and counting** link detections across multiple images in a sequence, supporting population estimates, behavioral analysis, and occupancy modeling.
+
+
+## Detection vs. Classification — Why MegaDetector Is a Detector
+
+MegaDetector is intentionally a **detector**, not a classifier. It outputs three categories — animal, person, vehicle — and does not identify species.
+
+This is not a limitation. It is a design choice with significant practical advantages:
+
+**Better generalization.** A model trained to answer "is there an animal?" generalizes far more easily across continents, ecosystems, and species assemblages than a model trained to answer "what species is this?" Species classifiers must be retrained or fine-tuned for each new region and fauna. A single MegaDetector model works on African savanna, North American forest, tropical rainforest, and sub-Antarctic penguin colonies.
+
+**Lower annotation cost.** Training a detector requires bounding-box annotations labeled as "animal," "person," or "vehicle." Training a species classifier requires those same bounding boxes labeled with species identity — which requires expert taxonomic knowledge for every species in every geographic region. Detector training is far cheaper to scale.
+
+**Cleaner workflow.** Separating detection from classification gives researchers control over each step. You can swap classifiers, tune thresholds independently, or skip classification entirely when species ID is not needed.
+
+The result is a two-stage workflow that is used by more than 80 conservation organizations worldwide:
+
+```
+Camera-trap images
+    → MegaDetector (detect animals, filter blanks)
+    → Species classifier (identify detected animals)
+    → Analysis
+```
+
+
+## When to Use MegaDetector
+
+**Good fit:**
+- Large image datasets where manual review is the bottleneck
+- Projects spanning multiple ecosystems or geographic regions
+- Workflows that need a fast, reliable first pass before expert review
+- Edge deployment on low-power hardware ([SPARROW](https://github.com/microsoft/SPARROW) field units, Raspberry Pi, Jetson Nano)
+
+**Requires additional consideration:**
+- Aquatic wildlife or sonar imagery (see [MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar))
+- Overhead and aerial imagery (see [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead))
+- Bioacoustic monitoring (see [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic))
+- Species that are very small, heavily camouflaged, or rarely represented in training data — test on a labeled sample before committing to full deployment
+
+
+## The Broader Ecosystem
+
+MegaDetector is one layer in a larger open-source stack for wildlife AI. The [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella repository documents the full ecosystem:
+
+| Tool | Role |
+|---|---|
+| **MegaDetector** | Camera-trap detection — animals, people, vehicles |
+| [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife) | Framework hosting MegaDetector, classifiers, and training pipelines |
+| [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Species classification on top of MegaDetector detections |
+| [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Audio-based species detection from bioacoustic recordings |
+| [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Detection in aerial and satellite imagery |
+| [SPARROW](https://github.com/microsoft/SPARROW) | Solar-powered edge device running MegaDetector in the field |
+
+> [!TIP]
+> For a quick overview of what camera-trap software is available and how MegaDetector fits alongside other tools, see [Camera-Trap Software and Tools](camera-trap-software.md).
+
+
+## Get Started
+
+```bash
+pip install PytorchWildlife
+```
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+
+model = pw_detection.MegaDetectorV6()
+results = model.batch_image_detection("path/to/images/")
+```
+
+- [Installation guide](installation.md) — full setup including GPU and conda
+- [FAQ](faq.md) — common questions about accuracy, licensing, and V5 vs V6
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — try it without installing anything

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -1,0 +1,114 @@
+---
+description: "Camera-trap software overview — how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring software ecosystem."
+tags:
+  - camera trap software
+  - camera trap image analysis software
+  - EcoAssist
+  - AddaxAI
+  - Timelapse2
+  - Wildlife Insights
+  - CamtrapR
+  - MegaDetector tools
+  - wildlife monitoring software
+---
+
+# Camera-Trap Software and Tools
+
+MegaDetector is an AI model, not a complete camera-trap workflow. In practice it is used as one component in a larger pipeline, alongside tools for image management, review, and analysis. This page describes the major software tools in the camera-trap ecosystem and how MegaDetector fits with each.
+
+
+## The Camera-Trap Software Landscape
+
+Camera-trap workflows typically involve three layers:
+
+1. **Detection / filtering** — AI models that identify images containing animals and draw bounding boxes
+2. **Review / annotation** — interfaces where humans confirm detections, assign species labels, and export data
+3. **Analysis** — statistical and ecological analysis of the cleaned data (occupancy models, population estimates, activity patterns)
+
+Most practitioners combine tools from more than one layer. MegaDetector sits in layer 1.
+
+
+## MegaDetector
+
+**Role:** Detection and blank-frame filtering  
+**Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) — open-source, MIT license  
+**Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife)
+
+MegaDetector detects animals, people, and vehicles in camera-trap images. It does not classify species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+model = pw_detection.MegaDetectorV6()
+results = model.batch_image_detection("path/to/images/")
+```
+
+**Strengths:** Generalizes across ecosystems globally; compact V6 variants run on edge hardware; actively maintained with modern architectures (YOLOv9, YOLOv10, RT-DETR); free and open-source.
+
+
+## EcoAssist / AddaxAI
+
+**Role:** Desktop application wrapping MegaDetector for non-programmers  
+**Access:** [addaxdatascience.com](https://addaxdatascience.com/) — free  
+**Builds on:** MegaDetector
+
+EcoAssist (now rebranded AddaxAI) provides a graphical interface for running MegaDetector and downstream classifiers without writing code. It handles model selection, batch processing, threshold tuning, and results export in a point-and-click workflow. If you want MegaDetector without Python, AddaxAI is the recommended entry point.
+
+MegaDetector and AddaxAI are complementary: the model provides the AI backbone, AddaxAI provides the user interface.
+
+
+## Timelapse2
+
+**Role:** Image review and annotation  
+**Access:** [saul.cpsc.ucalgary.ca/timelapse](http://saul.cpsc.ucalgary.ca/timelapse) — free  
+**Integration:** Native MegaDetector import
+
+Timelapse2 is a desktop tool for reviewing large image sets from camera traps. It is designed to display images in temporal sequences, apply metadata, and record species observations efficiently. Timelapse2 has native support for importing MegaDetector JSON output, letting reviewers start with pre-filtered, AI-annotated images rather than raw files.
+
+**Typical workflow:** Run MegaDetector → import results into Timelapse2 → human review and species labeling.
+
+
+## Wildlife Insights
+
+**Role:** Cloud-based AI detection and species classification  
+**Access:** [wildlifeinsights.org](https://www.wildlifeinsights.org/) — free  
+**Model:** Google-developed AI (not MegaDetector)
+
+Wildlife Insights is a cloud platform from Google and conservation partners that offers end-to-end camera-trap processing: upload images, get AI species predictions, download results. It includes a web-based review interface and a growing database of camera-trap data.
+
+**Compared to MegaDetector:** Wildlife Insights is a full platform — it handles storage, classification, and data sharing in one place. MegaDetector is a local model that gives you more control over the pipeline and does not require uploading data to a third-party service. For sensitive data or offline deployments, MegaDetector is preferable. For rapid cloud-based processing with species predictions, Wildlife Insights is a strong option.
+
+
+## CamtrapR
+
+**Role:** R package for camera-trap data analysis  
+**Access:** [CRAN / jniedballa.github.io/camtrapR](https://jniedballa.github.io/camtrapR) — open-source  
+**Layer:** Analysis (not detection)
+
+CamtrapR is an R package for processing and analyzing camera-trap data — it handles activity patterns, species detection histories, occupancy modeling inputs, and report generation. It works on annotated data, not raw images.
+
+CamtrapR complements MegaDetector: after MegaDetector filters blanks and a reviewer assigns species labels, CamtrapR handles the downstream statistical analysis.
+
+
+## Summary
+
+| Tool | Layer | Species ID | Requires code | Data stays local | Cost |
+|---|---|---|---|---|---|
+| **MegaDetector** | Detection | No (animal/person/vehicle only) | Optional (or via AddaxAI) | Yes | Free |
+| AddaxAI | Detection (GUI) | Via classifiers | No | Yes | Free |
+| Timelapse2 | Review | Human-assigned | No | Yes | Free |
+| Wildlife Insights | Detection + classification | Yes (AI) | No | No (cloud upload) | Free |
+| CamtrapR | Analysis | N/A | Yes (R) | Yes | Free |
+
+> [!TIP]
+> For MegaDetector's graphical interfaces, see [SPARROW Studio](https://github.com/microsoft/SPARROW) (full desktop app) and the [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) (browser-based, no install).
+
+
+## Get Started with MegaDetector
+
+```bash
+pip install PytorchWildlife
+```
+
+- [Installation guide](installation.md) — setup including GPU and conda options
+- [FAQ](faq.md) — accuracy, licensing, V5 vs V6, and more
+- [Camera-Trap AI](camera-trap-ai.md) — how detection and classification work together

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,130 @@
+---
+description: "MegaDetector FAQ — frequently asked questions about installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to use MegaDetector for camera-trap wildlife detection."
+tags:
+  - MegaDetector FAQ
+  - MegaDetector how to
+  - camera trap AI questions
+  - MegaDetector accuracy
+  - MegaDetector license
+  - V5 vs V6
+---
+
+# Frequently Asked Questions
+
+## What is MegaDetector?
+
+MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images. It draws bounding boxes around detected objects and assigns a confidence score between 0 and 1.
+
+MegaDetector is a **detector**, not a classifier — it tells you *something is there*, not what species it is. This design choice is intentional: a single detector generalizes across ecosystems far better than a species classifier, which is typically region-specific. For species identification, pair MegaDetector with a downstream classifier.
+
+
+## What does MegaDetector detect?
+
+MegaDetector detects three categories:
+
+| Category | Examples |
+|---|---|
+| Animal | Mammals, birds, reptiles, insects, fish — any wildlife |
+| Person | Researchers, poachers, tourists |
+| Vehicle | Cars, trucks, ATVs |
+
+It does not identify species. An image containing a lion and a zebra returns two "animal" detections, not "lion" and "zebra."
+
+
+## Do I need a GPU?
+
+No — MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets (tens of thousands of images or more), but is not required.
+
+The compact MegaDetectorV6 variants (YOLOv10-Compact, YOLOv9-Compact) are specifically designed for low-budget devices and edge hardware like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
+
+
+## What is the difference between MegaDetectorV5 and MegaDetectorV6?
+
+| | MegaDetectorV5 | MegaDetectorV6 |
+|---|---|---|
+| Architecture | YOLOv5 | YOLOv9, YOLOv10, RT-DETR (multiple variants) |
+| Parameters (compact) | 139.9M | 2.3M (YOLOv10-Compact — 2% of V5) |
+| License | MIT | MIT |
+| Status | Maintained by Dan Morris at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) | Current release — recommended for new projects |
+| Weights | Available on [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) | Download automatically via PyTorch-Wildlife |
+
+**Recommendation:** Use MegaDetectorV6 for new projects. MegaDetectorV5 remains available and is actively maintained by the community.
+
+> [!TIP]
+> For detailed model variants and benchmark results, see the [Model Zoo](model_zoo.md).
+
+
+## How accurate is MegaDetector?
+
+Accuracy depends on the dataset and confidence threshold. MegaDetectorV6 compact variants achieve comparable accuracy to V5 at 2% of the parameter count on the AI for Good Lab's validation datasets.
+
+In practice, most deployments use a confidence threshold of 0.15–0.3 for the "animal" category, which provides high recall (few missed animals) at the cost of some false positives on vegetation and lighting artifacts. Setting the threshold higher reduces false positives but risks missing low-confidence true detections.
+
+MegaDetector generalizes well across ecosystems because it was trained on a large and geographically diverse dataset. Performance is typically strongest on large mammals and degrades on very small or camouflaged animals.
+
+
+## What species does MegaDetector support?
+
+All of them — with caveats. MegaDetector detects the presence of an animal, not the species. It has been deployed on projects involving African savanna megafauna, North American forest species, European ungulates, tropical insects, and marine wildlife.
+
+Performance varies. Large mammals in open habitat are reliably detected. Very small animals, heavily camouflaged species, or unusual angles may have lower confidence scores. If you're working with an atypical dataset, we recommend testing on a labeled sample before full deployment.
+
+
+## How do I run MegaDetector?
+
+The quickest path is three lines of Python:
+
+```bash
+pip install PytorchWildlife
+```
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+model = pw_detection.MegaDetectorV6()
+results = model.batch_image_detection("path/to/image_folder/")
+```
+
+For a graphical interface, use [SPARROW Studio](https://github.com/microsoft/SPARROW) or the [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife).
+
+See [Installation](installation.md) for full setup instructions.
+
+
+## What is the license?
+
+MegaDetector is released under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE). You can use it for any purpose, including commercial use, subject to the license terms.
+
+The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-licensed. Individual model weights may carry separate licenses — see the [Model Zoo](model_zoo.md) for per-model licensing information.
+
+
+## What is Dan Morris's fork?
+
+Dan Morris developed MegaDetector V1–V5 during his time at Microsoft. He continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which includes an extensive set of helper scripts, batch processing tools, and documentation accumulated over years of community use. It remains a valuable resource — especially for users of V5 weights or the original `run_detector_batch.py` workflow.
+
+The `microsoft/MegaDetector` repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community.
+
+
+## Where are the V5 weights?
+
+MegaDetectorV5 weights are available on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the `microsoft/Biodiversity` repository (formerly `microsoft/CameraTraps`). Dan Morris's fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) also hosts V5 and provides extensive tooling around it.
+
+
+## How do I cite MegaDetector?
+
+A `CITATION.cff` is maintained in this repository for automated citation tools (Zenodo, GitHub's "Cite this repository" button).
+
+For MegaDetector specifically, cite:
+
+> Beery, Morris, Yang (2019). *Efficient Pipeline for Camera Trap Image Review*. arXiv:1907.06772.
+
+For the PyTorch-Wildlife framework:
+
+> Hernandez et al. (2024). *Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation*. arXiv:2311.11890.
+
+See [Cite Us](cite.md) for full citation details and BibTeX.
+
+
+## Where do I get help?
+
+- **GitHub Issues:** [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) — bug reports and feature requests
+- **Discord:** [Join the PyTorch-Wildlife server](https://discord.gg/TeEVxzaYtm) — community support and discussion
+- **Email:** [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,8 +73,11 @@ nav:
     - Overview: index.md
     - Installation: installation.md
     - Model Zoo: model_zoo.md
+    - FAQ: faq.md
     - Tags: tags.md
-  - Fine-tuning:
+  - Guides:
+    - Camera-Trap AI: camera-trap-ai.md
+    - Camera-Trap Software: camera-trap-software.md
     - Training Guide: training_guide.md
   - Cite Us: cite.md
   - Developer Guide: build_mkdocs.md


### PR DESCRIPTION
## Summary

Adds three new docs pages targeting the problem/use-case and task/tutorial SEO keyword clusters identified in the Phase 1 SEO plan. These are the three pages flagged as missing from the `microsoft/MegaDetector` docs site.

## Files changed

| File | Purpose | SEO target |
|---|---|---|
| `docs/faq.md` | Frequently Asked Questions — accuracy, GPU, V5 vs V6, licensing, species support, Dan Morris fork, V5 weights, citations | FAQ / navigational queries |
| `docs/camera-trap-ai.md` | What camera-trap AI is, why blank-frame filtering matters, detector vs. classifier design, when to use MegaDetector | Problem/use-case keyword cluster |
| `docs/camera-trap-software.md` | MegaDetector positioned alongside EcoAssist/AddaxAI, Timelapse2, Wildlife Insights, and CamtrapR with a comparison table | Tooling/comparison keyword cluster |
| `mkdocs.yml` | Nav updated: FAQ added under MegaDetector section; new Guides section for the two explainers and Training Guide | — |

## Verification

`mkdocs build` clean (0.83s, no new warnings).

## Related

ADO Epic 506340 (Phase 1 — Repo Optimization). Completes the missing docs pages identified in the 2026-05-18 Phase 1 audit.