### PR TITLE
Fix broken repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
 
-MegaDetector is one project in the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) ecosystem and is invoked through the [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife) framework. It is free, open-source, and available under permissive licenses.
+MegaDetector is one project in the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) ecosystem and is invoked through the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. It is free, open-source, and available under permissive licenses.
 
 [![PyPI](https://img.shields.io/pypi/v/PytorchWildlife?color=limegreen)](https://pypi.org/project/PytorchWildlife)
 [![Downloads](https://static.pepy.tech/badge/pytorchwildlife)](https://pypi.org/project/PytorchWildlife)
@@ -190,7 +190,7 @@ MegaDetector is one model in a larger open-source ecosystem from the AI for Good
 | Repo | Purpose |
 | --- | --- |
 | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
-| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework that hosts MegaDetector, species classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, DeepFaune), HerdNet, PW-Engine (a Rust-based inference core), and demo notebooks |
+| [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework that hosts MegaDetector, species classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, DeepFaune), HerdNet, PW-Engine (a Rust-based inference core), and demo notebooks |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in remote field locations |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
@@ -215,7 +215,7 @@ MegaDetector is used by 80+ organizations across government agencies, universiti
 
 **Platforms**: TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network, OCAPI, WildePod
 
-See the [full list](https://github.com/microsoft/PytorchWildlife#who-uses-megadetector) in the PyTorch-Wildlife repository.
+See the [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) in the PyTorch-Wildlife repository.
 
 
 ## Performance
@@ -329,7 +329,7 @@ You can also use GitHub's "Cite this repository" button in the sidebar.
 
 MegaDetector's source code lives in this repository. To contribute code, file issues, or submit pull requests, head to [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues).
 
-For framework-level changes (PyTorch-Wildlife API, classifiers, demo notebooks), see [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife). For ecosystem-wide questions, see the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
+For framework-level changes (PyTorch-Wildlife API, classifiers, demo notebooks), see [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife). For ecosystem-wide questions, see the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
 
 For questions, feature requests, or to report how MegaDetector worked on your data:
 - **Email**: [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)

--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -76,7 +76,7 @@ MegaDetector is one layer in a larger open-source stack for wildlife AI. The [mi
 | Tool | Role |
 |---|---|
 | **MegaDetector** | Camera-trap detection — animals, people, vehicles |
-| [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife) | Framework hosting MegaDetector, classifiers, and training pipelines |
+| [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | Framework hosting MegaDetector, classifiers, and training pipelines |
 | [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Species classification on top of MegaDetector detections |
 | [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Audio-based species detection from bioacoustic recordings |
 | [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Detection in aerial and satellite imagery |

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -32,7 +32,7 @@ Most practitioners combine tools from more than one layer. MegaDetector sits in 
 
 **Role:** Detection and blank-frame filtering  
 **Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) — open-source, MIT license  
-**Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife)
+**Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife)
 
 MegaDetector detects animals, people, and vehicles in camera-trap images. It does not classify species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ tags:
 # MegaDetector
 
 > [!TIP]
-> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella — the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife).
+> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella — the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
 
 **MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
 
@@ -78,7 +78,7 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | --- | --- |
 | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
 | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal detection in camera-trap imagery |
-| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
+| [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ tags:
 
 # Installation
 
-MegaDetector is installed as part of the [PyTorch-Wildlife](https://github.com/microsoft/PytorchWildlife) framework.
+MegaDetector is installed as part of the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework.
 
 ```bash
 pip install PytorchWildlife

--- a/megadetector.md
+++ b/megadetector.md
@@ -9,7 +9,7 @@
 # 🐾 MegaDetector
 
 > [!TIP]
-> MegaDetector now has its own home at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector). The full model zoo and PyTorch-Wildlife framework live at [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife), with everything tied together under the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
+> MegaDetector now has its own home at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector). The full model zoo and PyTorch-Wildlife framework live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife), with everything tied together under the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella.
 
 **MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
 
@@ -34,7 +34,7 @@ We will continuously fine-tune our V6 models on newly collected public and priva
 > [!TIP]
 > All versions of MegaDetector and corresponding performance can be found in the [model zoo](https://microsoft.github.io/MegaDetector/model_zoo/megadetector/).
 
-> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model fits the project needs. To reduce potential confusion, we have also standardized the model names into **MDV6-Compact** and **MDV6-Extra** for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/PytorchWildlife/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/MegaDetector/demo_and_ui/demo_data/).
+> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model fits the project needs. To reduce potential confusion, we have also standardized the model names into **MDV6-Compact** and **MDV6-Extra** for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/Pytorch-Wildlife/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/MegaDetector/demo_and_ui/demo_data/).
 
 
 ## MegaDetectorV5 and Archive Repos
@@ -50,9 +50,9 @@ MegaDetector is one project in a larger open-source ecosystem from the AI for Go
 | --- | --- |
 | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
 | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal detection in camera-trap imagery |
-| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
+| [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
-| [microsoft/MegaDetector-Acoustics](https://github.com/microsoft/MegaDetector-Acoustics) | Bioacoustic models for audio-based wildlife monitoring |
+| [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | SPARROW Studio | The desktop application that wraps it all in a graphical interface |
 


### PR DESCRIPTION
## Summary
- `github.com/microsoft/PytorchWildlife` → `github.com/microsoft/Pytorch-Wildlife` (missing dash — flagged by Miao)
- `github.com/microsoft/MegaDetector-Acoustics` → `github.com/microsoft/MegaDetector-Acoustic` (spurious trailing "s")

## Files changed
- `megadetector.md` (3 URL refs + Acoustics fix)
- `README.md` (3 URL refs)
- `docs/index.md` (1 URL ref)
- `docs/installation.md` (1 URL ref)
- `docs/camera-trap-software.md` (1 URL ref)
- `docs/camera-trap-ai.md` (1 URL ref)

## Notes
PyPI package name (`pip install PytorchWildlife`, `from PytorchWildlife.models import ...`) is unchanged — that's the correct package name on PyPI.