### PR TITLE
fix(seo): suppress homepage tag chips via hide:tags while keeping the tag index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
 ---
 description: "MegaDetector: open-source AI model from Microsoft AI for Good Lab that detects animals, people, and vehicles in camera-trap images. Used by 80+ conservation organizations worldwide."
-hide:
-  - tags
 tags:
   - MegaDetector
   - MegaDetectorV6

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 ---
 description: "MegaDetector: open-source AI model from Microsoft AI for Good Lab that detects animals, people, and vehicles in camera-trap images. Used by 80+ conservation organizations worldwide."
+hide:
+  - tags
 tags:
   - MegaDetector
   - MegaDetectorV6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ copyright: Copyright (c) 2023 Microsoft Corporation
 
 theme:
   name: material
+  custom_dir: overrides
   favicon: https://zenodo.org/records/15376499/files/cat.png
   logo: https://zenodo.org/records/15376499/files/cat.png
   icon:

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,19 @@
+{#-
+  Override of Material's partials/content.html (mkdocs-material 9.7.6).
+
+  Only change vs. upstream: the `partials/tags.html` include is moved from the
+  top of the article to AFTER `{{ page.content }}`. Material renders the tag
+  chips above the H1 by default, so crawlers see a row of tag links as the
+  page's leading content instead of the H1/intro. Moving the include below the
+  content keeps the tag chips and their links (tag SEO intact) while letting the
+  H1/intro lead the DOM.
+-#}
+{% include "partials/actions.html" %}
+{% if "<h1" not in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+{{ page.content }}
+{% include "partials/tags.html" %}
+{% include "partials/source-file.html" %}
+{% include "partials/feedback.html" %}
+{% include "partials/comments.html" %}


### PR DESCRIPTION
## What

Suppresses the tag chips on the homepage so they stop leading the page content (and search snippets), while keeping the tags system intact.

- `docs/index.md` front matter: adds `hide: [tags]` (Material's documented per-page control).

## Why

Material renders the page tag chips *above* the H1, so the first content a crawler sees on the homepage is a row of tag chips rather than the H1 and intro. `hide: tags` removes the rendered chip block from the homepage only.

## Notes for review

- This is **not** a CSS reorder — a CSS `order:` change leaves the chip text leading the DOM. `hide: tags` adds `hidden` to the chip `<nav>`, so the H1/intro lead the content.
- **The tags plugin and the browsable `tags.md` index are unchanged** — all 51 tags still render on the tag index and on other pages; only the homepage chip block is suppressed.
- **Rebase note:** `docs/homepage-seo-content` and `feat/jsonld-structured-data` also touch `docs/index.md` front matter; trivial rebase if this merges second.

Verified with `mkdocs build --strict`: homepage `md-tags` nav carries `hidden`; `tags.md` index still lists all tags.
