### PR TITLE
feat(seo): add JSON-LD structured data via theme override (SoftwareSourceCode, FAQPage, BreadcrumbList)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,7 +118,7 @@ For MegaDetector specifically, cite:
 
 For the PyTorch-Wildlife framework:
 
-> Hernandez et al. (2024). *Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation*. arXiv:2311.11890.
+> Hernandez et al. (2024). *Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation*. arXiv:2405.12930.
 
 See [Cite Us](cite.md) for full citation details and BibTeX.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ copyright: Copyright (c) 2023 Microsoft Corporation
 
 theme:
   name: material
+  custom_dir: overrides
   favicon: https://zenodo.org/records/15376499/files/cat.png
   logo: https://zenodo.org/records/15376499/files/cat.png
   icon:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{#
+  Theme override for SEO structured data and a clean homepage <title>.
+  Schema is gated on page.file.src_path (unique per page, cannot be copied
+  between pages by accident) rather than a front-matter flag.
+#}
+
+{% block htmltitle %}
+  {%- if page and page.file and page.file.src_path == "index.md" -%}
+  <title>MegaDetector: Open-Source Camera-Trap AI | Microsoft AI for Good</title>
+  {%- else -%}
+  {{ super() }}
+  {%- endif -%}
+{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+
+  {%- if page and page.file and page.file.src_path == "index.md" %}
+  {#- Homepage: SoftwareSourceCode (entity clarity for an open-source model/code project) -#}
+  <script type="application/ld+json">
+  {{- {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "@id": config.site_url ~ "#software",
+    "name": "MegaDetector",
+    "description": config.site_description,
+    "url": config.site_url,
+    "codeRepository": config.repo_url,
+    "programmingLanguage": "Python",
+    "runtimePlatform": "Python",
+    "isAccessibleForFree": true,
+    "license": "https://github.com/microsoft/MegaDetector/blob/main/LICENSE",
+    "creator": {
+      "@type": "Organization",
+      "name": "Microsoft AI for Good Lab",
+      "url": "https://www.microsoft.com/en-us/ai/ai-for-good"
+    },
+    "keywords": ["MegaDetector", "camera trap AI", "wildlife detection", "animal detection", "conservation AI", "blank frame filtering", "PyTorch-Wildlife"]
+  } | tojson -}}
+  </script>
+  {%- endif %}
+
+  {%- if page and page.file and page.file.src_path == "faq.md" %}
+  {#- FAQ page only: FAQPage. Answers mirror the visible faq.md text. -#}
+  <script type="application/ld+json">
+  {{- {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is MegaDetector?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetector is an open-source AI model from the Microsoft AI for Good Lab that detects animals, people, and vehicles in camera-trap images. It is a detector, not a classifier — it tells you something is there, not what species it is. For species identification, pair MegaDetector with a downstream classifier."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What does MegaDetector detect?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetector detects three categories: animal, person, and vehicle. It does not identify species — an image containing a lion and a zebra returns two animal detections, not lion and zebra."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do I need a GPU?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No — MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets, but is not required. Compact MegaDetectorV6 variants are designed for low-budget devices and edge hardware."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the difference between MegaDetectorV5 and MegaDetectorV6?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetectorV5 uses the YOLOv5 architecture (139.9M parameters). MegaDetectorV6 uses modern architectures (YOLOv9, YOLOv10, RT-DETR) with compact variants as small as 2.3M parameters. Use MegaDetectorV6 for new projects; MegaDetectorV5 remains community-maintained by Dan Morris."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the license?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetector is released under the MIT License — free for any purpose including commercial use, subject to the license terms. The PyTorch-Wildlife framework that distributes it is also MIT-licensed; individual model weights may carry separate licenses."
+        }
+      }
+    ]
+  } | tojson -}}
+  </script>
+  {%- endif %}
+
+  {%- if page and page.file and page.file.src_path != "index.md" and page.canonical_url %}
+  {#- Interior pages only: BreadcrumbList (no breadcrumb on the homepage) -#}
+  <script type="application/ld+json">
+  {{- {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "MegaDetector", "item": config.site_url },
+      { "@type": "ListItem", "position": 2, "name": page.title | striptags, "item": page.canonical_url }
+    ]
+  } | tojson -}}
+  </script>
+  {%- endif %}
+{% endblock %}


### PR DESCRIPTION
## What

Adds JSON-LD structured data and a clean homepage `<title>` via a Material theme override.

- `mkdocs.yml`: `theme.custom_dir: overrides`.
- New `overrides/main.html` (extends `base.html`, injects in `extrahead`), gated on `page.file.src_path`:
  - **SoftwareSourceCode** — homepage only.
  - **FAQPage** — `faq.md` only; answers mirror the visible FAQ text.
  - **BreadcrumbList** — interior pages only (not the homepage), absolute `/MegaDetector/` URLs.
  - Homepage-scoped `htmltitle` override so the homepage `<title>` is exactly `MegaDetector: Open-Source Camera-Trap AI | Microsoft AI for Good` (no appended ` - MegaDetector`).
- `docs/faq.md`: fixes the PyTorch-Wildlife citation arXiv ID `2311.11890` → `2405.12930` (the former is an unrelated paper).

## Why

Structured data gives search engines explicit entity signals. Material has no JSON-LD plugin, so a `custom_dir` override is the supported injection point.

## Notes for review

- **`SoftwareSourceCode`, not `SoftwareApplication`** — the latter's rich result requires `offers.price` + rating/review, which we won't fabricate. This is for entity clarity.
- **FAQ rich results were retired by Google on 2026-05-07** — the `FAQPage` markup is shipped for entity/content clarity, not a SERP snippet.
- Schema is gated on `page.file.src_path` (unique per page) so a flag can't accidentally leak homepage schema onto another page. JSON is built with Jinja `| tojson` for safe escaping — all blocks validated as parseable JSON locally.
- **Rebase note:** touches `docs/index.md`/`docs/faq.md` lightly; `docs/homepage-seo-content` and `fix/tag-chip-snippet` also touch `docs/index.md` front matter.

Validate at the Rich Results Test / Schema Markup Validator after deploy.
