### PR TITLE
docs: SEO-optimized MegaDetector homepage rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MegaDetector
 
-**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Used by conservation organizations worldwide, MegaDetector automates camera-trap image review so researchers can skip empty frames and focus on science. It is a detector, not a species classifier — it finds and boxes objects, then hands them to a downstream classifier for species identification.
 
 MegaDetector is one project in the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) ecosystem and is invoked through the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. It is free, open-source, and available under permissive licenses.
 
@@ -44,7 +44,7 @@ Need the local `megadetector` CLI or fine-tuning? See [Install from source](#ins
 
 Camera traps generate millions of images, and the vast majority are empty frames triggered by wind or vegetation. Manually reviewing them is one of the biggest bottlenecks in wildlife research.
 
-MegaDetector solves this. It scans your images and draws bounding boxes around any animal — mammals, birds, reptiles, insects, and more. Each detection has a confidence score between 0 and 1. You set a threshold (typically 0.15–0.3), and anything above it is flagged. The output lets you sort images, filter blanks, or feed detected animals into a species classifier.
+MegaDetector solves this. It scans your images and draws bounding boxes around every **animal** (mammals, birds, reptiles, insects, and more), **person**, and **vehicle** it finds. Each detection has a confidence score between 0 and 1. You set a threshold (typically 0.15–0.3), and anything above it is flagged. The output lets you sort images, filter blanks, separate human and vehicle traffic, or feed detected animals into a species classifier.
 
 MegaDetector is intentionally a **detector**, not a classifier. "Animal vs. background" generalizes across ecosystems far better than species identification. For species classification, pair MegaDetector with a downstream classifier — see [Species Classification](#species-classification) below.
 
@@ -63,18 +63,18 @@ The latest release focuses on **efficiency** and **modern architectures** — **
 
 | Model | Params | Animal Recall | mAP50 | License |
 | --- | --- | --- | --- | --- |
+| MDV6-apa-rtdetr-e | 76M | 82.9% | 94.1% | Apache-2.0 |
 | MDV6-yolov10-e | 29.5M | 82.8% | 92.8% | AGPL-3.0 |
-| MDV6-yolov9-e | 58.1M | 82.1% | 88.6% | AGPL-3.0 |
-| MDV6-rtdetr-c | 31.9M | 81.6% | 89.9% | AGPL-3.0 |
-| MDV6-yolov9-c | 25.5M | 78.4% | 87.9% | AGPL-3.0 |
 | MDV6-yolov10-c | 2.3M | 76.8% | 87.2% | AGPL-3.0 |
+| MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
 
-Model names are standardized into **MDV6-Compact** and **MDV6-Extra** for the two model sizes within each architecture, reducing confusion across variants.
+A representative selection — the full nine-variant lineup (YOLOv9, YOLOv10, and RT-DETR, with MIT, Apache-2.0, and AGPL-3.0 options) with all metrics lives in the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
 
 **Which should I use?**
-- **Best accuracy**: MDV6-yolov10-e (82.8% recall, AGPL-3.0)
-- **Best for laptops/edge**: MDV6-yolov10-c (2.3M params, runs on CPU)
-- **Best balance**: MDV6-yolov10-e (29.5M params, 82.8% recall)
+- **Best accuracy**: `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
+- **Best for laptops/edge**: `MDV6-yolov10-c` (2.3M params, runs on CPU)
+- **Permissive MIT license**: `MDV6-mit-yolov9-c`
+- **Best via the `megadetector` CLI**: `MDV6-yolov10-e` — the CLI's `--model` flag supports `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c`; the MIT and Apache variants load through PyTorch-Wildlife.
 
 ```python
 # Load a specific variant
@@ -82,6 +82,13 @@ from PytorchWildlife.models import detection as pw_detection
 
 model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")
 ```
+
+
+## Which MegaDetector Repo Should I Use?
+
+Use **this repository (`microsoft/MegaDetector`)** for MegaDetector V6: the current models, the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/), the fine-tuning pipeline, and the [documentation site](https://microsoft.github.io/MegaDetector/). It is the official home maintained by the Microsoft AI for Good Lab.
+
+If you are maintaining a legacy V5 workflow, the original models and tooling remain available: V5 weights live on the [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive), and project founder **Dan Morris** maintains a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with extensive V5-era helper scripts. For new projects, start with V6 here.
 
 
 ## Installation
@@ -203,7 +210,7 @@ MegaDetector is the entry point for most users. SPARROW Studio is the full platf
 
 ## Organizations Using MegaDetector
 
-MegaDetector is used by 80+ organizations across government agencies, universities, NGOs, and technology companies worldwide. A selection:
+MegaDetector is used by conservation organizations worldwide — government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [PyTorch-Wildlife list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector):
 
 **Government**: Arizona DEQ, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada (Banff), U.S. Fish & Wildlife Service (multiple refuges), National Park Service, Canadian Wildlife Service
 
@@ -339,4 +346,4 @@ For questions, feature requests, or to report how MegaDetector worked on your da
 
 ## License
 
-The MegaDetector code is released under the [MIT License](LICENSE). Individual model weights documented in this repository are released under AGPL-3.0 — see the [Model Variants](#model-variants) table for details.
+The MegaDetector **code** in this repository is released under the [MIT License](LICENSE). The **model weights** carry per-variant licenses — MIT, Apache-2.0, or AGPL-3.0 depending on the variant — so check the license of the specific model you deploy. See the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/) for each variant's license.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ That's it. Three lines to detect animals in your camera-trap images.
 Need the local `megadetector` CLI or fine-tuning? See [Install from source](#install-from-source-for-fine-tuning-or-cli-use) and [Fine-Tuning](#fine-tuning) below.
 
 **Try it without installing anything:**
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), free cloud GPU
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): free cloud GPU
 
 
 ## What Does MegaDetector Do?
@@ -56,8 +56,8 @@ The latest release focuses on **efficiency** and **modern architectures**, **SMA
 ### Highlights
 
 - **50x smaller**: The compact YOLOv10 variant has **2.3M parameters**, 2% of MegaDetector V5's 139.9M, with comparable accuracy
-- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR, pick the one that fits your hardware
-- **Ongoing fine-tuning**: V6 models are continuously fine-tuned on newly collected public and private data to further improve generalization
+- **Multiple architectures**: YOLOv9, YOLOv10, and RT-DETR, so you can match the model to your hardware
+- **Ongoing fine-tuning**: we keep retraining V6 on freshly collected public and private data to push generalization further
 
 ### Model Variants
 
@@ -68,13 +68,13 @@ The latest release focuses on **efficiency** and **modern architectures**, **SMA
 | MDV6-yolov10-c | 2.3M | 76.8% | 87.2% | AGPL-3.0 |
 | MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
 
-A representative selection, the full nine-variant lineup (YOLOv9, YOLOv10, and RT-DETR, with MIT, Apache-2.0, and AGPL-3.0 options) with all metrics lives in the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
+This is a representative selection. The full nine-variant lineup (YOLOv9, YOLOv10, and RT-DETR, with MIT, Apache-2.0, and AGPL-3.0 options) and all metrics live in the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
 
 **Which should I use?**
 - **Best accuracy**: `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
 - **Best for laptops/edge**: `MDV6-yolov10-c` (2.3M params, runs on CPU)
 - **Permissive MIT license**: `MDV6-mit-yolov9-c`
-- **Best via the `megadetector` CLI**: `MDV6-yolov10-e`, the CLI's `--model` flag supports `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c`; the MIT and Apache variants load through PyTorch-Wildlife.
+- **Best via the `megadetector` CLI**: `MDV6-yolov10-e`. The CLI's `--model` flag supports `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c`; the MIT and Apache variants load through PyTorch-Wildlife.
 
 ```python
 # Load a specific variant
@@ -88,7 +88,7 @@ model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")
 
 Use **this repository (`microsoft/MegaDetector`)** for MegaDetector V6: the current models, the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/), the fine-tuning pipeline, and the [documentation site](https://microsoft.github.io/MegaDetector/). It is the official home maintained by the Microsoft AI for Good Lab.
 
-If you are maintaining a legacy V5 workflow, the original models and tooling remain available: V5 weights live on the [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive), and project founder **Dan Morris** maintains a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with extensive V5-era helper scripts. For new projects, start with V6 here.
+If you are maintaining a legacy V5 workflow, the original models and tooling remain available: V5 weights live on the [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive), and project founder **Dan Morris** keeps the original tooling alive in a fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) full of V5-era helper scripts. For new projects, start with V6 here.
 
 
 ## Installation
@@ -126,7 +126,7 @@ pip install -e .
 
 This installs the `megadetector_core` Python package and exposes the
 `megadetector` shell command (`megadetector detect|train|validate|inference`).
-The `pyproject.toml` covers the full dependency set, no separate
+The `pyproject.toml` covers the full dependency set, so no separate
 `requirements.txt` is needed.
 
 Full installation guide: [microsoft.github.io/MegaDetector/installation/](https://microsoft.github.io/MegaDetector/installation/)
@@ -134,7 +134,7 @@ Full installation guide: [microsoft.github.io/MegaDetector/installation/](https:
 
 ## How Do I Run MegaDetector? (Python, CLI, or No-Code)
 
-There are three ways to run MegaDetector, pick the one that fits your workflow:
+There are three ways to run MegaDetector. Choose whichever suits your workflow:
 
 | You are… | Use | How |
 | --- | --- | --- |
@@ -182,12 +182,12 @@ Start at **0.2**, the CLI default, and tune from there. Most projects use a thre
 
 ## What Are MegaDetector's Limitations?
 
-MegaDetector is accurate across many terrestrial ecosystems, but it is not perfect. Very small or distant animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence and can be missed. Aquatic, overhead/aerial, and acoustic monitoring fall outside its scope, those are handled by sibling models ([MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar), [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead), and [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic)). If your dataset is atypical, measure recall on a labeled sample before relying on it at scale.
+MegaDetector is accurate across many terrestrial ecosystems, but it is not perfect. Very small or distant animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence and can be missed. Aquatic, overhead/aerial, and acoustic monitoring fall outside its scope. Those are handled by sibling models ([MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar), [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead), and [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic)). If your dataset is atypical, measure recall on a labeled sample before relying on it at scale.
 
 
 ## Can MegaDetector Identify Species?
 
-MegaDetector finds animals, it doesn't identify species. For species ID, run a two-stage pipeline:
+MegaDetector finds animals but doesn't identify their species. For species ID, run a two-stage pipeline:
 
 1. **MegaDetector** detects and localizes animals
 2. **A species classifier** identifies the species in each crop
@@ -310,9 +310,7 @@ No, MegaDetector runs on a CPU. A CUDA-capable NVIDIA GPU delivers a **10–50×
 | Modern CPU (no GPU) | MDV6-yolov10-c (2.3M) | ~2–5 images/sec |
 | Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
 
-At 50 images/sec on a GPU, **one million images takes about 5.5 hours**; on CPU with the compact model, about 3.9 days. Every V6 variant is faster than the 139.9M-parameter V5.
-
-Every V6 variant is faster than V5 (139.9M params). The compact V6 is 2% the size.
+At 50 images/sec on a GPU, **one million images takes about 5.5 hours**; on CPU with the compact model, about 3.9 days. Even the largest V6 variant outruns the 139.9M-parameter V5, and the compact build is roughly 2% its size.
 
 
 ## Fine-Tuning
@@ -373,7 +371,7 @@ API equivalents of each CLI subcommand.
 
 For MegaDetectorV5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-The original MegaDetector repository was primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a forked version at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which remains a valuable resource for the community.
+MegaDetector V1–V5 were primarily built by **Dan Morris** at Microsoft. He now maintains the [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) fork, which many V5 users still rely on.
 
 
 ## Our Commitment

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Need the local `megadetector` CLI or fine-tuning? See [Install from source](#ins
 
 ## What Does MegaDetector Do?
 
-Camera traps generate millions of images, and the vast majority are empty frames triggered by wind or vegetation. Manually reviewing them is one of the biggest bottlenecks in wildlife research.
+Camera traps generate millions of images, and in typical deployments **70–95% are empty** — frames triggered by wind, rain, or moving vegetation. Sorting those by hand is one of the biggest bottlenecks in wildlife research, and it scales badly: more cameras mean exponentially more images to clear before any science can begin.
 
 MegaDetector solves this. It scans your images and draws bounding boxes around every **animal** (mammals, birds, reptiles, insects, and more), **person**, and **vehicle** it finds. Each detection has a confidence score between 0 and 1. You set a threshold (typically 0.15–0.3), and anything above it is flagged. The output lets you sort images, filter blanks, separate human and vehicle traffic, or feed detected animals into a species classifier.
 
@@ -132,7 +132,60 @@ The `pyproject.toml` covers the full dependency set — no separate
 Full installation guide: [microsoft.github.io/MegaDetector/installation/](https://microsoft.github.io/MegaDetector/installation/)
 
 
-## Species Classification
+## How Do I Run MegaDetector? (Python, CLI, or No-Code)
+
+There are three ways to run MegaDetector — pick the one that fits your workflow:
+
+| You are… | Use | How |
+| --- | --- | --- |
+| A Python developer | the `PytorchWildlife` API | `MegaDetectorV6().batch_image_detection("images/")` — see [Quick Start](#quick-start) |
+| Comfortable in a terminal | the `megadetector` CLI | `megadetector detect --input ./images/ --output results.json` |
+| Not a coder | a graphical app | [SPARROW Studio](#desktop-and-web-interfaces) or [AddaxAI](#desktop-and-web-interfaces) |
+
+The CLI ships with the package and wraps the same models:
+
+```bash
+# Detect on a folder, write JSON, choose a model and threshold
+megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e --threshold 0.2
+```
+
+`--model` accepts `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c` (default `MDV6-yolov9-c`); `--device` takes `cuda:0`, `cpu`, or `mps` (auto-detected if omitted). The same CLI exposes `train`, `validate`, and `inference` for fine-tuning. Full reference: [CLI guide](https://microsoft.github.io/MegaDetector/cli/).
+
+
+## What Does MegaDetector Output Look Like?
+
+MegaDetector returns one record per image: the file path plus a list of detections, each carrying a category (`animal`, `person`, or `vehicle`), a confidence score from 0 to 1, and a bounding box as `[x1, y1, x2, y2]` pixel coordinates.
+
+```json
+[
+  {
+    "file": "images/IMG_0001.jpg",
+    "detections": [
+      { "category": "animal", "confidence": 0.93, "bbox": [102.4, 88.1, 540.7, 470.2] }
+    ]
+  }
+]
+```
+
+Only detections at or above your threshold are kept. When run from the CLI, MegaDetector also prints a short summary — images processed, total detections, and how many images contain at least one animal — so you can sanity-check a batch at a glance. This JSON feeds directly into review tools such as Timelapse or into a downstream species classifier. Full schema: [Output Format guide](https://microsoft.github.io/MegaDetector/output_format/).
+
+
+## How Accurate Is MegaDetector?
+
+Accuracy depends on your data and threshold, so the honest answer is always: **test it on your own images before trusting any number.** On the AI for Good Lab's validation sets, the larger V6 variants report animal recall above 82%, and the compact `MDV6-yolov10-c` reaches comparable accuracy at 2% of V5's parameter count. MegaDetector generalizes well across ecosystems because it was trained on a large, geographically diverse dataset, and it performs best on large mammals in open habitat. See the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/) for per-variant recall and mAP50.
+
+
+## What Confidence Threshold Should I Use?
+
+Start at **0.2** — the CLI default — and tune from there. Most projects use a threshold between **0.15 and 0.3** for the animal category. Lower values catch more true animals (higher recall) at the cost of more false positives on vegetation and lighting artifacts; higher values trim false positives but risk dropping low-confidence real detections. Because calibration varies by ecosystem, label a small sample and pick the threshold that balances missed animals against review effort for *your* data.
+
+
+## What Are MegaDetector's Limitations?
+
+MegaDetector is accurate across many terrestrial ecosystems, but it is not perfect. Very small or distant animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence and can be missed. Aquatic, overhead/aerial, and acoustic monitoring fall outside its scope — those are handled by sibling models ([MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar), [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead), and [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic)). If your dataset is atypical, measure recall on a labeled sample before relying on it at scale.
+
+
+## Can MegaDetector Identify Species?
 
 MegaDetector finds animals — it doesn't identify species. For species ID, run a two-stage pipeline:
 
@@ -190,6 +243,21 @@ Windows installer: [Download from Zenodo](https://zenodo.org/records/19687738/fi
 [Upload images and run MegaDetector in your browser](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — no installation required.
 
 
+## How Does MegaDetector Fit Into Camera-Trap Software?
+
+Camera-trap analysis has three layers: **detection** (filtering blanks and finding animals — MegaDetector's job), **review** (human verification and annotation), and **analysis** (occupancy, activity, and density modeling). MegaDetector sits in the detection layer and hands its output to the others.
+
+| Tool | Layer | Runs MegaDetector | Code required |
+| --- | --- | --- | --- |
+| MegaDetector | Detection | — | Python or CLI |
+| AddaxAI / SPARROW Studio | Detection (GUI) | Yes | No |
+| Timelapse | Review | Imports MD output | No |
+| Wildlife Insights | Cloud detect + review | Cloud pipeline | No |
+| CamtrapR | Analysis (R) | No | R |
+
+For how these tools fit together, see [Camera-Trap Software and Tools](https://microsoft.github.io/MegaDetector/camera-trap-software/); for the wider picture on AI in camera-trap workflows, see [Camera-Trap AI](https://microsoft.github.io/MegaDetector/camera-trap-ai/).
+
+
 ## Part of the Biodiversity Ecosystem
 
 MegaDetector is one model in a larger open-source ecosystem from the AI for Good Lab. Each project lives in its own repository, with the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella tying them together.
@@ -212,6 +280,7 @@ MegaDetector is the entry point for most users. SPARROW Studio is the full platf
 
 MegaDetector is used by conservation organizations worldwide — government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [PyTorch-Wildlife list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector):
 
+<!-- ATTESTED IN THIS REPO -->
 **Government**: Arizona DEQ, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada (Banff), U.S. Fish & Wildlife Service (multiple refuges), National Park Service, Canadian Wildlife Service
 
 **Conservation NGOs**: The Nature Conservancy, Island Conservation, Wildlife Protection Solutions, Australian Wildlife Conservancy, RSPB, CPAWS, SPEA, Felidae Conservation Fund
@@ -223,9 +292,16 @@ MegaDetector is used by conservation organizations worldwide — government agen
 **Platforms**: TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network, OCAPI, WildePod
 
 See the [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) in the PyTorch-Wildlife repository.
+<!-- /ATTESTED -->
+<!-- APPROVED-EXTERNAL: append reviewed organizations below this line -->
 
 
-## Performance
+## Do I Need a GPU?
+
+No — MegaDetector runs on a CPU. A CUDA-capable NVIDIA GPU delivers a **10–50× speedup** and is strongly recommended once you are processing tens of thousands of images, but it is not required to get started. The compact V6 variants (`MDV6-yolov10-c`, `MDV6-yolov9-c`) are designed specifically for low-budget and edge hardware, including the solar-powered [SPARROW](https://github.com/microsoft/SPARROW) field unit, so a modern laptop is enough for many projects. If a GPU is present, the CLI and the Python API detect and use it automatically; pass `--device cpu` to force CPU.
+
+
+## How Fast Is MegaDetector?
 
 | Hardware | Model | Approximate Speed |
 | --- | --- | --- |
@@ -234,7 +310,7 @@ See the [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megad
 | Modern CPU (no GPU) | MDV6-yolov10-c (2.3M) | ~2–5 images/sec |
 | Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
 
-At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU with the compact model, about 3.9 days.
+At 50 images/sec on a GPU, **one million images takes about 5.5 hours**; on CPU with the compact model, about 3.9 days. Every V6 variant is faster than the 139.9M-parameter V5.
 
 Every V6 variant is faster than V5 (139.9M params). The compact V6 is 2% the size.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MegaDetector
 
-**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Used by conservation organizations worldwide, MegaDetector automates camera-trap image review so researchers can skip empty frames and focus on science. It is a detector, not a species classifier — it finds and boxes objects, then hands them to a downstream classifier for species identification.
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Used by more than 80 conservation organizations worldwide, MegaDetector automates camera-trap image review so researchers can skip empty frames and focus on science. It is an animal detector, not a species classifier. It finds and boxes objects, then hands them to a downstream classifier for species identification.
 
 MegaDetector is one project in the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) ecosystem and is invoked through the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. It is free, open-source, and available under permissive licenses.
 
@@ -36,27 +36,27 @@ That's it. Three lines to detect animals in your camera-trap images.
 Need the local `megadetector` CLI or fine-tuning? See [Install from source](#install-from-source-for-fine-tuning-or-cli-use) and [Fine-Tuning](#fine-tuning) below.
 
 **Try it without installing anything:**
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), free cloud GPU
 
 
 ## What Does MegaDetector Do?
 
-Camera traps generate millions of images, and in typical deployments **70–95% are empty** — frames triggered by wind, rain, or moving vegetation. Sorting those by hand is one of the biggest bottlenecks in wildlife research, and it scales badly: more cameras mean exponentially more images to clear before any science can begin.
+Camera traps generate millions of images, and in typical deployments **70–95% are empty**, frames triggered by wind, rain, or moving vegetation. Sorting those by hand is one of the biggest bottlenecks in wildlife research, and it scales badly: more cameras mean exponentially more images to clear before any science can begin.
 
 MegaDetector solves this. It scans your images and draws bounding boxes around every **animal** (mammals, birds, reptiles, insects, and more), **person**, and **vehicle** it finds. Each detection has a confidence score between 0 and 1. You set a threshold (typically 0.15–0.3), and anything above it is flagged. The output lets you sort images, filter blanks, separate human and vehicle traffic, or feed detected animals into a species classifier.
 
-MegaDetector is intentionally a **detector**, not a classifier. "Animal vs. background" generalizes across ecosystems far better than species identification. For species classification, pair MegaDetector with a downstream classifier — see [Species Classification](#species-classification) below.
+MegaDetector is intentionally a **detector**, not a classifier. "Animal vs. background" generalizes across ecosystems far better than species identification. For species classification, pair MegaDetector with a downstream classifier, see [Species Classification](#species-classification) below.
 
 
 ## MegaDetector V6
 
-The latest release focuses on **efficiency** and **modern architectures** — **SMALLER, FASTER, BETTER**.
+The latest release focuses on **efficiency** and **modern architectures**, **SMALLER, FASTER, BETTER**.
 
 ### Highlights
 
-- **50x smaller**: The compact YOLOv10 variant has **2.3M parameters** — 2% of MegaDetector V5's 139.9M — with comparable accuracy
-- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR — pick the one that fits your hardware
+- **50x smaller**: The compact YOLOv10 variant has **2.3M parameters**, 2% of MegaDetector V5's 139.9M, with comparable accuracy
+- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR, pick the one that fits your hardware
 - **Ongoing fine-tuning**: V6 models are continuously fine-tuned on newly collected public and private data to further improve generalization
 
 ### Model Variants
@@ -68,13 +68,13 @@ The latest release focuses on **efficiency** and **modern architectures** — **
 | MDV6-yolov10-c | 2.3M | 76.8% | 87.2% | AGPL-3.0 |
 | MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
 
-A representative selection — the full nine-variant lineup (YOLOv9, YOLOv10, and RT-DETR, with MIT, Apache-2.0, and AGPL-3.0 options) with all metrics lives in the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
+A representative selection, the full nine-variant lineup (YOLOv9, YOLOv10, and RT-DETR, with MIT, Apache-2.0, and AGPL-3.0 options) with all metrics lives in the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
 
 **Which should I use?**
 - **Best accuracy**: `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
 - **Best for laptops/edge**: `MDV6-yolov10-c` (2.3M params, runs on CPU)
 - **Permissive MIT license**: `MDV6-mit-yolov9-c`
-- **Best via the `megadetector` CLI**: `MDV6-yolov10-e` — the CLI's `--model` flag supports `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c`; the MIT and Apache variants load through PyTorch-Wildlife.
+- **Best via the `megadetector` CLI**: `MDV6-yolov10-e`, the CLI's `--model` flag supports `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c`; the MIT and Apache variants load through PyTorch-Wildlife.
 
 ```python
 # Load a specific variant
@@ -126,7 +126,7 @@ pip install -e .
 
 This installs the `megadetector_core` Python package and exposes the
 `megadetector` shell command (`megadetector detect|train|validate|inference`).
-The `pyproject.toml` covers the full dependency set — no separate
+The `pyproject.toml` covers the full dependency set, no separate
 `requirements.txt` is needed.
 
 Full installation guide: [microsoft.github.io/MegaDetector/installation/](https://microsoft.github.io/MegaDetector/installation/)
@@ -134,11 +134,11 @@ Full installation guide: [microsoft.github.io/MegaDetector/installation/](https:
 
 ## How Do I Run MegaDetector? (Python, CLI, or No-Code)
 
-There are three ways to run MegaDetector — pick the one that fits your workflow:
+There are three ways to run MegaDetector, pick the one that fits your workflow:
 
 | You are… | Use | How |
 | --- | --- | --- |
-| A Python developer | the `PytorchWildlife` API | `MegaDetectorV6().batch_image_detection("images/")` — see [Quick Start](#quick-start) |
+| A Python developer | the `PytorchWildlife` API | `MegaDetectorV6().batch_image_detection("images/")`, see [Quick Start](#quick-start) |
 | Comfortable in a terminal | the `megadetector` CLI | `megadetector detect --input ./images/ --output results.json` |
 | Not a coder | a graphical app | [SPARROW Studio](#desktop-and-web-interfaces) or [AddaxAI](#desktop-and-web-interfaces) |
 
@@ -149,7 +149,7 @@ The CLI ships with the package and wraps the same models:
 megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e --threshold 0.2
 ```
 
-`--model` accepts `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c` (default `MDV6-yolov9-c`); `--device` takes `cuda:0`, `cpu`, or `mps` (auto-detected if omitted). The same CLI exposes `train`, `validate`, and `inference` for fine-tuning. Full reference: [CLI guide](https://microsoft.github.io/MegaDetector/cli/).
+The `--input` path can be a single image or a folder; folders are scanned recursively for `.jpg`, `.jpeg`, `.png`, `.bmp`, and `.tif`/`.tiff` files. `--model` accepts `MDV6-yolov9-c/e`, `MDV6-yolov10-c/e`, and `MDV6-rtdetr-c` (default `MDV6-yolov9-c`); `--device` takes `cuda:0`, `cpu`, or `mps` (auto-detected if omitted). The same CLI exposes `train`, `validate`, and `inference` for fine-tuning. Full reference: [CLI guide](https://microsoft.github.io/MegaDetector/cli/).
 
 
 ## What Does MegaDetector Output Look Like?
@@ -167,7 +167,7 @@ MegaDetector returns one record per image: the file path plus a list of detectio
 ]
 ```
 
-Only detections at or above your threshold are kept. When run from the CLI, MegaDetector also prints a short summary — images processed, total detections, and how many images contain at least one animal — so you can sanity-check a batch at a glance. This JSON feeds directly into review tools such as Timelapse or into a downstream species classifier. Full schema: [Output Format guide](https://microsoft.github.io/MegaDetector/output_format/).
+Only detections at or above your threshold are kept. When run from the CLI, MegaDetector also prints a short summary, images processed, total detections, and how many images contain at least one animal, so you can sanity-check a batch at a glance. This JSON feeds directly into review tools such as Timelapse or into a downstream species classifier. Full schema: [Output Format guide](https://microsoft.github.io/MegaDetector/output_format/).
 
 
 ## How Accurate Is MegaDetector?
@@ -177,17 +177,17 @@ Accuracy depends on your data and threshold, so the honest answer is always: **t
 
 ## What Confidence Threshold Should I Use?
 
-Start at **0.2** — the CLI default — and tune from there. Most projects use a threshold between **0.15 and 0.3** for the animal category. Lower values catch more true animals (higher recall) at the cost of more false positives on vegetation and lighting artifacts; higher values trim false positives but risk dropping low-confidence real detections. Because calibration varies by ecosystem, label a small sample and pick the threshold that balances missed animals against review effort for *your* data.
+Start at **0.2**, the CLI default, and tune from there. Most projects use a threshold between **0.15 and 0.3** for the animal category. Lower values catch more true animals (higher recall) at the cost of more false positives on vegetation and lighting artifacts; higher values trim false positives but risk dropping low-confidence real detections. Because calibration varies by ecosystem, label a small sample and pick the threshold that balances missed animals against review effort for *your* data.
 
 
 ## What Are MegaDetector's Limitations?
 
-MegaDetector is accurate across many terrestrial ecosystems, but it is not perfect. Very small or distant animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence and can be missed. Aquatic, overhead/aerial, and acoustic monitoring fall outside its scope — those are handled by sibling models ([MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar), [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead), and [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic)). If your dataset is atypical, measure recall on a labeled sample before relying on it at scale.
+MegaDetector is accurate across many terrestrial ecosystems, but it is not perfect. Very small or distant animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence and can be missed. Aquatic, overhead/aerial, and acoustic monitoring fall outside its scope, those are handled by sibling models ([MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar), [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead), and [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic)). If your dataset is atypical, measure recall on a labeled sample before relying on it at scale.
 
 
 ## Can MegaDetector Identify Species?
 
-MegaDetector finds animals — it doesn't identify species. For species ID, run a two-stage pipeline:
+MegaDetector finds animals, it doesn't identify species. For species ID, run a two-stage pipeline:
 
 1. **MegaDetector** detects and localizes animals
 2. **A species classifier** identifies the species in each crop
@@ -240,16 +240,16 @@ Windows installer: [Download from Zenodo](https://zenodo.org/records/19687738/fi
 
 ### Hugging Face Space
 
-[Upload images and run MegaDetector in your browser](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — no installation required.
+[Upload images and run MegaDetector in your browser](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), no installation required.
 
 
 ## How Does MegaDetector Fit Into Camera-Trap Software?
 
-Camera-trap analysis has three layers: **detection** (filtering blanks and finding animals — MegaDetector's job), **review** (human verification and annotation), and **analysis** (occupancy, activity, and density modeling). MegaDetector sits in the detection layer and hands its output to the others.
+Camera-trap analysis has three layers: **detection** (filtering blanks and finding animals, MegaDetector's job), **review** (human verification and annotation), and **analysis** (occupancy, activity, and density modeling). MegaDetector sits in the detection layer and hands its output to the others.
 
 | Tool | Layer | Runs MegaDetector | Code required |
 | --- | --- | --- | --- |
-| MegaDetector | Detection | — | Python or CLI |
+| MegaDetector | Detection |, | Python or CLI |
 | AddaxAI / SPARROW Studio | Detection (GUI) | Yes | No |
 | Timelapse | Review | Imports MD output | No |
 | Wildlife Insights | Cloud detect + review | Cloud pipeline | No |
@@ -264,11 +264,11 @@ MegaDetector is one model in a larger open-source ecosystem from the AI for Good
 
 | Repo | Purpose |
 | --- | --- |
-| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
+| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository, documentation hub for the AI for Good Lab's biodiversity work |
 | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework that hosts MegaDetector, species classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, DeepFaune), HerdNet, PW-Engine (a Rust-based inference core), and demo notebooks |
-| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in remote field locations |
+| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch, the AI-enabled edge device that runs MegaDetector in remote field locations |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
-| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning, adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
 | SPARROW Studio | The desktop application that wraps it all in a graphical interface |
@@ -278,7 +278,7 @@ MegaDetector is the entry point for most users. SPARROW Studio is the full platf
 
 ## Organizations Using MegaDetector
 
-MegaDetector is used by conservation organizations worldwide — government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [PyTorch-Wildlife list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector):
+MegaDetector is used by more than 80 organizations worldwide, including government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [PyTorch-Wildlife list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector):
 
 <!-- ATTESTED IN THIS REPO -->
 **Government**: Arizona DEQ, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada (Banff), U.S. Fish & Wildlife Service (multiple refuges), National Park Service, Canadian Wildlife Service
@@ -298,7 +298,7 @@ See the [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megad
 
 ## Do I Need a GPU?
 
-No — MegaDetector runs on a CPU. A CUDA-capable NVIDIA GPU delivers a **10–50× speedup** and is strongly recommended once you are processing tens of thousands of images, but it is not required to get started. The compact V6 variants (`MDV6-yolov10-c`, `MDV6-yolov9-c`) are designed specifically for low-budget and edge hardware, including the solar-powered [SPARROW](https://github.com/microsoft/SPARROW) field unit, so a modern laptop is enough for many projects. If a GPU is present, the CLI and the Python API detect and use it automatically; pass `--device cpu` to force CPU.
+No, MegaDetector runs on a CPU. A CUDA-capable NVIDIA GPU delivers a **10–50× speedup** and is strongly recommended once you are processing tens of thousands of images, but it is not required to get started. The compact V6 variants (`MDV6-yolov10-c`, `MDV6-yolov9-c`) are designed specifically for low-budget and edge hardware, including the solar-powered [SPARROW](https://github.com/microsoft/SPARROW) field unit, so a modern laptop is enough for many projects. If a GPU is present, the CLI and the Python API detect and use it automatically; pass `--device cpu` to force CPU.
 
 
 ## How Fast Is MegaDetector?
@@ -321,7 +321,7 @@ MegaDetector V6 ships with a fine-tuning pipeline (built on the
 [ultralytics](https://github.com/ultralytics/ultralytics) framework) so you can
 adapt a V6 model to your own camera-trap dataset. Fine-tuning is useful when
 the off-the-shelf V6 models miss animals that look different from the training
-distribution — for example, an under-represented species, a specific
+distribution, for example, an under-represented species, a specific
 environment (forest canopy, snow, night-vision IR), or a new sensor.
 
 **Quick path:**
@@ -343,11 +343,11 @@ megadetector inference --config ./config.yaml
 
 **Supported fine-tuning model variants:**
 
-- `MDV6-yolov9-c` — compact YOLOv9
-- `MDV6-yolov9-e` — extra-large YOLOv9
-- `MDV6-yolov10-c` — compact YOLOv10 (2.3M params)
-- `MDV6-yolov10-e` — extra-large YOLOv10
-- `MDV6-rtdetr-c` — compact RT-DETR
+- `MDV6-yolov9-c`, compact YOLOv9
+- `MDV6-yolov9-e`, extra-large YOLOv9
+- `MDV6-yolov10-c`, compact YOLOv10 (2.3M params)
+- `MDV6-yolov10-e`, extra-large YOLOv10
+- `MDV6-rtdetr-c`, compact RT-DETR
 
 Training outputs (weights, plots, metrics) land under `./runs/` keyed by the
 `exp_name` field in your config. Fine-tuned `.pt` weights can be loaded back
@@ -364,9 +364,9 @@ API equivalents of each CLI subcommand.
 | --- | --- | --- | --- | --- |
 | **V6.0** (current) | 2024 | YOLOv9/v10, RT-DETR | 2.3M–58.1M | YOLOv9/v10 + RT-DETR variants (AGPL-3.0) |
 | V5.0 | 2022 | YOLOv5 | 139.9M | Two sub-versions (5a, 5b) |
-| V4.1 | 2020 | Faster R-CNN | — | Added vehicle class |
-| V3 | 2019 | Faster R-CNN | — | Added human class |
-| V2 | 2018 | Faster R-CNN | — | First public release |
+| V4.1 | 2020 | Faster R-CNN |, | Added vehicle class |
+| V3 | 2019 | Faster R-CNN |, | Added human class |
+| V2 | 2018 | Faster R-CNN |, | First public release |
 
 
 ## MegaDetector V5 and Earlier
@@ -378,7 +378,7 @@ The original MegaDetector repository was primarily developed by **Dan Morris** d
 
 ## Our Commitment
 
-At the core of our mission is the desire to create a harmonious space where conservation scientists from all over the globe can unite — to share, grow, and use datasets and deep learning architectures for wildlife conservation. We've been inspired by the potential and capabilities of MegaDetector, and we deeply value its contributions to the community. We remain committed to supporting, maintaining, and developing MegaDetector — ensuring its continued relevance, expansion, and utility.
+At the core of our mission is the desire to create a harmonious space where conservation scientists from all over the globe can unite, to share, grow, and use datasets and deep learning architectures for wildlife conservation. We've been inspired by the potential and capabilities of MegaDetector, and we deeply value its contributions to the community. We remain committed to supporting, maintaining, and developing MegaDetector, ensuring its continued relevance, expansion, and utility.
 
 
 ## Citing MegaDetector
@@ -422,4 +422,4 @@ For questions, feature requests, or to report how MegaDetector worked on your da
 
 ## License
 
-The MegaDetector **code** in this repository is released under the [MIT License](LICENSE). The **model weights** carry per-variant licenses — MIT, Apache-2.0, or AGPL-3.0 depending on the variant — so check the license of the specific model you deploy. See the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/) for each variant's license.
+The MegaDetector **code** in this repository is released under the [MIT License](LICENSE). The **model weights** carry per-variant licenses, MIT, Apache-2.0, or AGPL-3.0 depending on the variant, so check the license of the specific model you deploy. See the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/) for each variant's license.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,6 @@ The documentation site is built with MkDocs Material from the `docs/` directory.
 
 ## Next steps
 
-- [Contributing & Support](contributing.md) — how to file issues and submit changes
-- [CLI reference](cli.md) — the commands exposed by `megadetector_core`
-- [Training Guide](training_guide.md) — fine-tune a V6 model on your own data
+- [Contributing & Support](contributing.md), how to file issues and submit changes
+- [CLI reference](cli.md), the commands exposed by `megadetector_core`
+- [Training Guide](training_guide.md), fine-tune a V6 model on your own data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+---
+title: "MegaDetector Repository Architecture"
+description: "How the MegaDetector repository is organized: the megadetector_core package, the megadetector CLI entry point, model wrappers, and the fine-tuning pipeline."
+tags:
+  - megadetector repo structure
+  - megadetector_core
+  - package layout
+  - megadetector architecture
+  - contributing
+---
+
+# Repository Architecture
+
+This page orients contributors and integrators to how the `microsoft/MegaDetector` repository is laid out and how its pieces fit together.
+
+## Package and entry point
+
+The installable package is **`megadetector-core`**, with its source under `src/megadetector_core/`. Installing the repository registers a single console command:
+
+```
+megadetector = "megadetector_core.cli:main"
+```
+
+So `megadetector detect …` on the command line maps to `main()` in `megadetector_core/cli.py`. The package metadata, dependencies, and entry point all live in `pyproject.toml`; there is no separate `requirements.txt`.
+
+## Source layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/megadetector_core/cli.py` | Argument parsing and the `detect`, `train`, `validate`, and `inference` subcommands |
+| `src/megadetector_core/detector.py` | Thin wrappers around PyTorch-Wildlife's `MegaDetectorV6` (and `MegaDetectorV5` for backward compatibility) |
+| `src/megadetector_core/training.py` | Config-driven fine-tuning, validation, and inference, delegating to the underlying training framework |
+| `src/megadetector_core/training_utils.py` | Resolves and caches model weights, downloading them when they are not already present |
+| `examples/config_training.yaml` | Reference fine-tuning config you copy and edit |
+| `environment.yaml` | Conda environment definition for setup from source |
+
+## How it relates to PyTorch-Wildlife
+
+MegaDetector models are served through the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. The wrappers in `detector.py` instantiate PyTorch-Wildlife's `MegaDetectorV6`, so the CLI, the Python API, and PyTorch-Wildlife all run the same weights. Model files are downloaded on first use and cached locally, so no weights are committed to this repository.
+
+## The fine-tuning path
+
+`megadetector train|validate|inference` each read a YAML config that points at your dataset and hyperparameters, then call into `training.py`. Outputs (weights, plots, metrics) are written under `./runs/`, and a fine-tuned `.pt` file can be loaded straight back into `MegaDetectorV6(weights="path/to/best.pt")`. The full schema and data layout are documented in the [Training Guide](training_guide.md).
+
+## Documentation
+
+The documentation site is built with MkDocs Material from the `docs/` directory. To build or preview it locally, see the [Developer Guide](build_mkdocs.md).
+
+## Next steps
+
+- [Contributing & Support](contributing.md) — how to file issues and submit changes
+- [CLI reference](cli.md) — the commands exposed by `megadetector_core`
+- [Training Guide](training_guide.md) — fine-tune a V6 model on your own data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ This page orients contributors and integrators to how the `microsoft/MegaDetecto
 
 ## Package and entry point
 
-The installable package is **`megadetector-core`**, with its source under `src/megadetector_core/`. Installing the repository registers a single console command:
+MegaDetector installs as **`megadetector-core`**, with its source under `src/megadetector_core/`. Installing the repository registers a single console command:
 
 ```
 megadetector = "megadetector_core.cli:main"
@@ -44,10 +44,10 @@ MegaDetector models are served through the [PyTorch-Wildlife](https://github.com
 
 ## Documentation
 
-The documentation site is built with MkDocs Material from the `docs/` directory. To build or preview it locally, see the [Developer Guide](build_mkdocs.md).
+Docs are built with MkDocs Material from the `docs/` directory. To build or preview them locally, see the [Developer Guide](build_mkdocs.md).
 
 ## Next steps
 
-- [Contributing & Support](contributing.md), how to file issues and submit changes
-- [CLI reference](cli.md), the commands exposed by `megadetector_core`
-- [Training Guide](training_guide.md), fine-tune a V6 model on your own data
+- [Contributing & Support](contributing.md): how to file issues and submit changes
+- [CLI reference](cli.md): the commands exposed by `megadetector_core`
+- [Training Guide](training_guide.md): fine-tune a V6 model on your own data

--- a/docs/build_mkdocs.md
+++ b/docs/build_mkdocs.md
@@ -51,7 +51,7 @@ The site is available at `http://127.0.0.1:8000/`.
 
 ## 4. Deploy to GitHub Pages
 
-Push any change to `docs/**`, `mkdocs.yml`, or `requirements.txt` on the `main` branch — GitHub Actions deploys automatically.
+Push any change to `docs/**`, `mkdocs.yml`, or `requirements.txt` on the `main` branch, GitHub Actions deploys automatically.
 
 To deploy manually:
 

--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -1,5 +1,5 @@
 ---
-description: "Camera-trap AI explained, how machine learning automates wildlife monitoring, why AI-based detection matters for conservation, and how MegaDetector fits into the workflow."
+description: "Camera-trap AI explained: how machine learning automates wildlife monitoring, why detection matters for conservation, and where MegaDetector fits."
 tags:
   - camera trap AI
   - wildlife AI

--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -1,5 +1,5 @@
 ---
-description: "Camera-trap AI explained — how machine learning automates wildlife monitoring, why AI-based detection matters for conservation, and how MegaDetector fits into the workflow."
+description: "Camera-trap AI explained, how machine learning automates wildlife monitoring, why AI-based detection matters for conservation, and how MegaDetector fits into the workflow."
 tags:
   - camera trap AI
   - wildlife AI
@@ -10,11 +10,11 @@ tags:
   - camera trap image analysis
 ---
 
-# Camera-Trap AI — What It Is and Why It Matters
+# Camera-Trap AI, What It Is and Why It Matters
 
 ## The Camera-Trap Problem
 
-Camera traps are motion-triggered cameras deployed in the field to monitor wildlife. A single study may deploy hundreds of cameras over months or years, generating millions of images. The vast majority of those images are empty — triggered by wind, falling leaves, or temperature fluctuations rather than animals.
+Camera traps are motion-triggered cameras deployed in the field to monitor wildlife. A single study may deploy hundreds of cameras over months or years, generating millions of images. The vast majority of those images are empty, triggered by wind, falling leaves, or temperature fluctuations rather than animals.
 
 Manually reviewing millions of images is one of the biggest bottlenecks in wildlife research. A trained reviewer can process a few hundred images per hour; a million-image dataset requires weeks of focused effort before any analysis can begin. This review burden limits how much data researchers can realistically collect and delays conservation decisions that depend on timely species counts, presence/absence data, and behavioral observations.
 
@@ -32,15 +32,15 @@ AI-based tools automate the most time-consuming parts of image review:
 **Tracking and counting** link detections across multiple images in a sequence, supporting population estimates, behavioral analysis, and occupancy modeling.
 
 
-## Detection vs. Classification — Why MegaDetector Is a Detector
+## Detection vs. Classification, Why MegaDetector Is a Detector
 
-MegaDetector is intentionally a **detector**, not a classifier. It outputs three categories — animal, person, vehicle — and does not identify species.
+MegaDetector is intentionally a **detector**, not a classifier. It outputs three categories, animal, person, vehicle, and does not identify species.
 
 This is not a limitation. It is a design choice with significant practical advantages:
 
 **Better generalization.** A model trained to answer "is there an animal?" generalizes far more easily across continents, ecosystems, and species assemblages than a model trained to answer "what species is this?" Species classifiers must be retrained or fine-tuned for each new region and fauna. A single MegaDetector model works on African savanna, North American forest, tropical rainforest, and sub-Antarctic penguin colonies.
 
-**Lower annotation cost.** Training a detector requires bounding-box annotations labeled as "animal," "person," or "vehicle." Training a species classifier requires those same bounding boxes labeled with species identity — which requires expert taxonomic knowledge for every species in every geographic region. Detector training is far cheaper to scale.
+**Lower annotation cost.** Training a detector requires bounding-box annotations labeled as "animal," "person," or "vehicle." Training a species classifier requires those same bounding boxes labeled with species identity, which requires expert taxonomic knowledge for every species in every geographic region. Detector training is far cheaper to scale.
 
 **Cleaner workflow.** Separating detection from classification gives researchers control over each step. You can swap classifiers, tune thresholds independently, or skip classification entirely when species ID is not needed.
 
@@ -66,7 +66,7 @@ Camera-trap images
 - Aquatic wildlife or sonar imagery (see [MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar))
 - Overhead and aerial imagery (see [MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead))
 - Bioacoustic monitoring (see [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic))
-- Species that are very small, heavily camouflaged, or rarely represented in training data — test on a labeled sample before committing to full deployment
+- Species that are very small, heavily camouflaged, or rarely represented in training data, test on a labeled sample before committing to full deployment
 
 
 ## The Broader Ecosystem
@@ -75,7 +75,7 @@ MegaDetector is one layer in a larger open-source stack for wildlife AI. The [mi
 
 | Tool | Role |
 |---|---|
-| **MegaDetector** | Camera-trap detection — animals, people, vehicles |
+| **MegaDetector** | Camera-trap detection, animals, people, vehicles |
 | [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | Framework hosting MegaDetector, classifiers, and training pipelines |
 | [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Species classification on top of MegaDetector detections |
 | [MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Audio-based species detection from bioacoustic recordings |
@@ -99,6 +99,6 @@ model = pw_detection.MegaDetectorV6()
 results = model.batch_image_detection("path/to/images/")
 ```
 
-- [Installation guide](installation.md) — full setup including GPU and conda
-- [FAQ](faq.md) — common questions about accuracy, licensing, and V5 vs V6
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — try it without installing anything
+- [Installation guide](installation.md), full setup including GPU and conda
+- [FAQ](faq.md), common questions about accuracy, licensing, and V5 vs V6
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), try it without installing anything

--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -34,7 +34,7 @@ AI-based tools automate the most time-consuming parts of image review:
 
 ## Detection vs. Classification, Why MegaDetector Is a Detector
 
-MegaDetector is intentionally a **detector**, not a classifier. It outputs three categories, animal, person, vehicle, and does not identify species.
+MegaDetector is intentionally a **detector**, not a classifier. It outputs three categories (animal, person, vehicle) and does not identify species.
 
 This is not a limitation. It is a design choice with significant practical advantages:
 
@@ -44,7 +44,7 @@ This is not a limitation. It is a design choice with significant practical advan
 
 **Cleaner workflow.** Separating detection from classification gives researchers control over each step. You can swap classifiers, tune thresholds independently, or skip classification entirely when species ID is not needed.
 
-The result is a two-stage workflow that is used by more than 80 conservation organizations worldwide:
+The result is a two-stage workflow now adopted by more than 80 conservation organizations around the world:
 
 ```
 Camera-trap images
@@ -99,6 +99,6 @@ model = pw_detection.MegaDetectorV6()
 results = model.batch_image_detection("path/to/images/")
 ```
 
-- [Installation guide](installation.md), full setup including GPU and conda
-- [FAQ](faq.md), common questions about accuracy, licensing, and V5 vs V6
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), try it without installing anything
+- [Installation guide](installation.md): full setup including GPU and conda
+- [FAQ](faq.md): common questions about accuracy, licensing, and V5 vs V6
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): try it without installing anything

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -75,7 +75,7 @@ Timelapse2 is a desktop tool for reviewing large image sets from camera traps. I
 
 Wildlife Insights is a cloud platform from Google and conservation partners that offers end-to-end camera-trap processing: upload images, get AI species predictions, download results. It includes a web-based review interface and a growing database of camera-trap data.
 
-**Compared to MegaDetector:** Wildlife Insights is a full platform, it handles storage, classification, and data sharing in one place. MegaDetector is a local model that gives you more control over the pipeline and does not require uploading data to a third-party service. For sensitive data or offline deployments, MegaDetector is preferable. For rapid cloud-based processing with species predictions, Wildlife Insights is a strong option.
+**Compared to MegaDetector:** Wildlife Insights is a full platform that handles storage, classification, and data sharing in one place. MegaDetector is a local model that gives you more control over the pipeline and does not require uploading data to a third-party service. For sensitive data or offline deployments, MegaDetector is preferable. For rapid cloud-based processing with species predictions, Wildlife Insights is a strong option.
 
 
 ## CamtrapR
@@ -84,7 +84,7 @@ Wildlife Insights is a cloud platform from Google and conservation partners that
 **Access:** [CRAN / jniedballa.github.io/camtrapR](https://jniedballa.github.io/camtrapR), open-source  
 **Layer:** Analysis (not detection)
 
-CamtrapR is an R package for processing and analyzing camera-trap data, it handles activity patterns, species detection histories, occupancy modeling inputs, and report generation. It works on annotated data, not raw images.
+CamtrapR is an R package for processing and analyzing camera-trap data. It handles activity patterns, species detection histories, occupancy-modeling inputs, and report generation. It works on annotated data, not raw images.
 
 CamtrapR complements MegaDetector: after MegaDetector filters blanks and a reviewer assigns species labels, CamtrapR handles the downstream statistical analysis.
 
@@ -109,6 +109,6 @@ CamtrapR complements MegaDetector: after MegaDetector filters blanks and a revie
 pip install PytorchWildlife
 ```
 
-- [Installation guide](installation.md), setup including GPU and conda options
-- [FAQ](faq.md), accuracy, licensing, V5 vs V6, and more
-- [Camera-Trap AI](camera-trap-ai.md), how detection and classification work together
+- [Installation guide](installation.md): setup including GPU and conda options
+- [FAQ](faq.md): accuracy, licensing, V5 vs V6, and more
+- [Camera-Trap AI](camera-trap-ai.md): how detection and classification work together

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -34,7 +34,7 @@ Most practitioners combine tools from more than one layer. MegaDetector sits in 
 **Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) — open-source, MIT license  
 **Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife)
 
-MegaDetector detects animals, people, and vehicles in camera-trap images. It does not classify species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
+MegaDetector detects animals, people, and vehicles in camera-trap images, but does not classify them to species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
 
 ```python
 from PytorchWildlife.models import detection as pw_detection

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -1,5 +1,5 @@
 ---
-description: "Camera-trap software overview — how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring software ecosystem."
+description: "Camera-trap software overview, how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring software ecosystem."
 tags:
   - camera trap software
   - camera trap image analysis software
@@ -21,9 +21,9 @@ MegaDetector is an AI model, not a complete camera-trap workflow. In practice it
 
 Camera-trap workflows typically involve three layers:
 
-1. **Detection / filtering** — AI models that identify images containing animals and draw bounding boxes
-2. **Review / annotation** — interfaces where humans confirm detections, assign species labels, and export data
-3. **Analysis** — statistical and ecological analysis of the cleaned data (occupancy models, population estimates, activity patterns)
+1. **Detection / filtering**, AI models that identify images containing animals and draw bounding boxes
+2. **Review / annotation**, interfaces where humans confirm detections, assign species labels, and export data
+3. **Analysis**, statistical and ecological analysis of the cleaned data (occupancy models, population estimates, activity patterns)
 
 Most practitioners combine tools from more than one layer. MegaDetector sits in layer 1.
 
@@ -31,10 +31,10 @@ Most practitioners combine tools from more than one layer. MegaDetector sits in 
 ## MegaDetector
 
 **Role:** Detection and blank-frame filtering  
-**Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) — open-source, MIT license  
+**Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector), open-source, MIT license  
 **Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife)
 
-MegaDetector detects animals, people, and vehicles in camera-trap images, but does not classify them to species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
+MegaDetector detects animals, people, and vehicles in camera-trap images, but does not classify them to species. Its primary function is to compress large image datasets before human review, removing blank frames and surfacing images that contain animals.
 
 ```python
 from PytorchWildlife.models import detection as pw_detection
@@ -48,7 +48,7 @@ results = model.batch_image_detection("path/to/images/")
 ## EcoAssist / AddaxAI
 
 **Role:** Desktop application wrapping MegaDetector for non-programmers  
-**Access:** [addaxdatascience.com](https://addaxdatascience.com/) — free  
+**Access:** [addaxdatascience.com](https://addaxdatascience.com/), free  
 **Builds on:** MegaDetector
 
 EcoAssist (now rebranded AddaxAI) provides a graphical interface for running MegaDetector and downstream classifiers without writing code. It handles model selection, batch processing, threshold tuning, and results export in a point-and-click workflow. If you want MegaDetector without Python, AddaxAI is the recommended entry point.
@@ -59,7 +59,7 @@ MegaDetector and AddaxAI are complementary: the model provides the AI backbone, 
 ## Timelapse2
 
 **Role:** Image review and annotation  
-**Access:** [saul.cpsc.ucalgary.ca/timelapse](http://saul.cpsc.ucalgary.ca/timelapse) — free  
+**Access:** [saul.cpsc.ucalgary.ca/timelapse](http://saul.cpsc.ucalgary.ca/timelapse), free  
 **Integration:** Native MegaDetector import
 
 Timelapse2 is a desktop tool for reviewing large image sets from camera traps. It is designed to display images in temporal sequences, apply metadata, and record species observations efficiently. Timelapse2 has native support for importing MegaDetector JSON output, letting reviewers start with pre-filtered, AI-annotated images rather than raw files.
@@ -70,21 +70,21 @@ Timelapse2 is a desktop tool for reviewing large image sets from camera traps. I
 ## Wildlife Insights
 
 **Role:** Cloud-based AI detection and species classification  
-**Access:** [wildlifeinsights.org](https://www.wildlifeinsights.org/) — free  
+**Access:** [wildlifeinsights.org](https://www.wildlifeinsights.org/), free  
 **Model:** Google-developed AI (not MegaDetector)
 
 Wildlife Insights is a cloud platform from Google and conservation partners that offers end-to-end camera-trap processing: upload images, get AI species predictions, download results. It includes a web-based review interface and a growing database of camera-trap data.
 
-**Compared to MegaDetector:** Wildlife Insights is a full platform — it handles storage, classification, and data sharing in one place. MegaDetector is a local model that gives you more control over the pipeline and does not require uploading data to a third-party service. For sensitive data or offline deployments, MegaDetector is preferable. For rapid cloud-based processing with species predictions, Wildlife Insights is a strong option.
+**Compared to MegaDetector:** Wildlife Insights is a full platform, it handles storage, classification, and data sharing in one place. MegaDetector is a local model that gives you more control over the pipeline and does not require uploading data to a third-party service. For sensitive data or offline deployments, MegaDetector is preferable. For rapid cloud-based processing with species predictions, Wildlife Insights is a strong option.
 
 
 ## CamtrapR
 
 **Role:** R package for camera-trap data analysis  
-**Access:** [CRAN / jniedballa.github.io/camtrapR](https://jniedballa.github.io/camtrapR) — open-source  
+**Access:** [CRAN / jniedballa.github.io/camtrapR](https://jniedballa.github.io/camtrapR), open-source  
 **Layer:** Analysis (not detection)
 
-CamtrapR is an R package for processing and analyzing camera-trap data — it handles activity patterns, species detection histories, occupancy modeling inputs, and report generation. It works on annotated data, not raw images.
+CamtrapR is an R package for processing and analyzing camera-trap data, it handles activity patterns, species detection histories, occupancy modeling inputs, and report generation. It works on annotated data, not raw images.
 
 CamtrapR complements MegaDetector: after MegaDetector filters blanks and a reviewer assigns species labels, CamtrapR handles the downstream statistical analysis.
 
@@ -109,6 +109,6 @@ CamtrapR complements MegaDetector: after MegaDetector filters blanks and a revie
 pip install PytorchWildlife
 ```
 
-- [Installation guide](installation.md) — setup including GPU and conda options
-- [FAQ](faq.md) — accuracy, licensing, V5 vs V6, and more
-- [Camera-Trap AI](camera-trap-ai.md) — how detection and classification work together
+- [Installation guide](installation.md), setup including GPU and conda options
+- [FAQ](faq.md), accuracy, licensing, V5 vs V6, and more
+- [Camera-Trap AI](camera-trap-ai.md), how detection and classification work together

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -1,5 +1,5 @@
 ---
-description: "Camera-trap software overview, how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring software ecosystem."
+description: "Camera-trap software overview: how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring stack."
 tags:
   - camera trap software
   - camera trap image analysis software

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,5 +1,5 @@
 ---
-description: "How to cite MegaDetector and PyTorch-Wildlife in research. BibTeX citations for the MegaDetector model (Beery 2019) and the PyTorch-Wildlife framework (Hernandez 2024)."
+description: "How to cite MegaDetector and PyTorch-Wildlife in research, with BibTeX for the MegaDetector model (Beery 2019) and the framework (Hernandez 2024)."
 tags:
   - MegaDetector citation
   - PyTorch-Wildlife citation
@@ -15,6 +15,8 @@ If MegaDetector contributed to your research, please cite the relevant papers be
 
 ## PyTorch-Wildlife (the framework)
 
+Read the paper on arXiv: [arXiv:2405.12930](https://arxiv.org/abs/2405.12930).
+
 ```bibtex
 @misc{hernandez2024pytorchwildlife,
       title={Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation},
@@ -27,6 +29,8 @@ If MegaDetector contributed to your research, please cite the relevant papers be
 
 
 ## MegaDetector (the original model)
+
+Preprint: [arXiv:1907.06772](https://arxiv.org/abs/1907.06772).
 
 ```bibtex
 @misc{beery2019efficient,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,85 @@
+---
+title: "MegaDetector CLI — detect, train, validate, inference"
+description: "MegaDetector CLI reference: run detection on camera-trap images with the megadetector detect command, plus train, validate, and inference subcommands."
+tags:
+  - megadetector cli
+  - megadetector detect
+  - command line
+  - batch detection
+  - camera trap AI
+---
+
+# MegaDetector CLI
+
+The `megadetector` command-line tool runs MegaDetector on a single image or a whole folder without writing any Python. It ships with the editable install of this repository and wraps the same V6 models exposed by the Python API.
+
+## Install the CLI
+
+The CLI is registered when you install the repository from source:
+
+```bash
+git clone https://github.com/microsoft/MegaDetector
+cd MegaDetector
+pip install -e .
+```
+
+This installs the `megadetector_core` package and the `megadetector` command. Verify it:
+
+```bash
+megadetector --help
+```
+
+## Detect
+
+`megadetector detect` is the command you will use most. It accepts either a single image or a directory (scanned recursively for `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, and `.tiff` files).
+
+```bash
+# Single image, print results to the terminal
+megadetector detect --input photo.jpg
+
+# A folder, write results to JSON, pick a model and threshold
+megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e --threshold 0.2
+
+# Force CPU
+megadetector detect --input ./images/ --device cpu
+```
+
+### Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--input`, `-i` | *(required)* | Path to an image file or a directory of images |
+| `--output`, `-o` | *(stdout)* | Path to write JSON results; prints to the terminal if omitted |
+| `--model`, `-m` | `MDV6-yolov9-c` | Model variant (see supported list below) |
+| `--threshold`, `-t` | `0.2` | Minimum confidence to keep a detection |
+| `--device`, `-d` | *(auto)* | `cuda:0`, `cpu`, or `mps`; auto-detects a GPU if omitted |
+
+### Supported models
+
+The `--model` flag accepts five V6 variants:
+
+`MDV6-yolov9-c`, `MDV6-yolov9-e`, `MDV6-yolov10-c`, `MDV6-yolov10-e`, and `MDV6-rtdetr-c`.
+
+The MIT and Apache-2.0 variants documented in the [Model Zoo](model_zoo.md) (for example `MDV6-apa-rtdetr-e`) are loaded through the PyTorch-Wildlife Python API rather than the CLI's `--model` flag.
+
+### What you get back
+
+The command writes a JSON list — one entry per image, each with a `file` path and a list of `detections`. When it finishes, it also prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
+
+## Fine-tuning subcommands
+
+The same CLI drives the fine-tuning workflow, each subcommand reading a YAML config:
+
+```bash
+megadetector train    --config ./config.yaml
+megadetector validate --config ./config.yaml
+megadetector inference --config ./config.yaml
+```
+
+`--config` defaults to `./config.yaml`. For the data layout, the full config schema, and the Python API equivalents, see the [Training Guide](training_guide.md).
+
+## Next steps
+
+- [Output Format](output_format.md) — interpret the JSON MegaDetector produces
+- [Model Zoo](model_zoo.md) — every variant, with recall, mAP50, and license
+- [Installation](installation.md) — environment setup and GPU configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ The `megadetector` command-line tool runs MegaDetector on a single image or a wh
 
 ## Install the CLI
 
-The CLI is registered when you install the repository from source:
+Installing the repository from source registers the CLI:
 
 ```bash
 git clone https://github.com/microsoft/MegaDetector
@@ -56,7 +56,7 @@ megadetector detect --input ./images/ --device cpu
 
 ### Supported models
 
-The `--model` flag accepts five V6 variants:
+Five V6 variants are available to `--model`:
 
 `MDV6-yolov9-c`, `MDV6-yolov9-e`, `MDV6-yolov10-c`, `MDV6-yolov10-e`, and `MDV6-rtdetr-c`.
 
@@ -64,7 +64,7 @@ The MIT and Apache-2.0 variants documented in the [Model Zoo](model_zoo.md) (for
 
 ### What you get back
 
-The command writes a JSON list, one entry per image, each with a `file` path and a list of `detections`. When it finishes, it also prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
+Each run writes a JSON list with one entry per image, holding a `file` path and a list of `detections`. When it finishes, the command prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
 
 ## Fine-tuning subcommands
 
@@ -80,6 +80,6 @@ megadetector inference --config ./config.yaml
 
 ## Next steps
 
-- [Output Format](output_format.md), interpret the JSON MegaDetector produces
-- [Model Zoo](model_zoo.md), every variant, with recall, mAP50, and license
-- [Installation](installation.md), environment setup and GPU configuration
+- [Output Format](output_format.md): interpret the JSON MegaDetector produces
+- [Model Zoo](model_zoo.md): every variant, with recall, mAP50, and license
+- [Installation](installation.md): environment setup and GPU configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,5 @@
 ---
-title: "MegaDetector CLI — detect, train, validate, inference"
+title: "MegaDetector CLI, detect, train, validate, inference"
 description: "MegaDetector CLI reference: run detection on camera-trap images with the megadetector detect command, plus train, validate, and inference subcommands."
 tags:
   - megadetector cli
@@ -64,7 +64,7 @@ The MIT and Apache-2.0 variants documented in the [Model Zoo](model_zoo.md) (for
 
 ### What you get back
 
-The command writes a JSON list — one entry per image, each with a `file` path and a list of `detections`. When it finishes, it also prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
+The command writes a JSON list, one entry per image, each with a `file` path and a list of `detections`. When it finishes, it also prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
 
 ## Fine-tuning subcommands
 
@@ -80,6 +80,6 @@ megadetector inference --config ./config.yaml
 
 ## Next steps
 
-- [Output Format](output_format.md) — interpret the JSON MegaDetector produces
-- [Model Zoo](model_zoo.md) — every variant, with recall, mAP50, and license
-- [Installation](installation.md) — environment setup and GPU configuration
+- [Output Format](output_format.md), interpret the JSON MegaDetector produces
+- [Model Zoo](model_zoo.md), every variant, with recall, mAP50, and license
+- [Installation](installation.md), environment setup and GPU configuration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,12 +25,12 @@ The MegaDetector ecosystem spans a few repositories, so routing your report to t
 
 ## Reporting bugs and requesting features
 
-Open an issue on [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues). Helpful reports include the model variant and threshold you used, the command or code that triggered the problem, and a sample of the output. If you are reporting how MegaDetector performed on your data — good or bad — that feedback is genuinely useful for improving the models.
+Open an issue on [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues). Helpful reports include the model variant and threshold you used, the command or code that triggered the problem, and a sample of the output. If you are reporting how MegaDetector performed on your data, good or bad, that feedback is genuinely useful for improving the models.
 
 ## Submitting changes
 
 1. Fork the repository and create a branch for your change.
-2. Make your edits — for code, the [Repository Architecture](architecture.md) page explains the package layout; for docs, the [Developer Guide](build_mkdocs.md) covers building the site locally.
+2. Make your edits, for code, the [Repository Architecture](architecture.md) page explains the package layout; for docs, the [Developer Guide](build_mkdocs.md) covers building the site locally.
 3. Open a pull request describing the change and the motivation.
 
 Documentation improvements are welcome and are often the easiest first contribution.
@@ -41,12 +41,12 @@ Please do **not** report security vulnerabilities through public GitHub issues. 
 
 ## Getting help
 
-- **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
-- **GitHub Discussions** — [microsoft/Biodiversity/discussions](https://github.com/microsoft/Biodiversity/discussions)
-- **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Discord**, [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
+- **GitHub Discussions**, [microsoft/Biodiversity/discussions](https://github.com/microsoft/Biodiversity/discussions)
+- **Email**, [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
 
 ## Next steps
 
-- [Repository Architecture](architecture.md) — orient yourself in the codebase
-- [Developer Guide](build_mkdocs.md) — build and preview the docs
-- [FAQ](faq.md) — common questions before you file an issue
+- [Repository Architecture](architecture.md), orient yourself in the codebase
+- [Developer Guide](build_mkdocs.md), build and preview the docs
+- [FAQ](faq.md), common questions before you file an issue

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,52 @@
+---
+title: "Contributing to MegaDetector & Getting Support"
+description: "How to contribute to MegaDetector and get help: filing issues, submitting pull requests, reporting security concerns, and reaching the community."
+tags:
+  - contribute to megadetector
+  - megadetector support
+  - report a bug
+  - megadetector community
+  - security
+---
+
+# Contributing & Support
+
+MegaDetector is open source and community-driven. This page explains where to file things, how to contribute changes, and how to get help.
+
+## Where does my issue belong?
+
+The MegaDetector ecosystem spans a few repositories, so routing your report to the right place gets it answered faster:
+
+| Your topic | Repository |
+| --- | --- |
+| MegaDetector models, the CLI, fine-tuning, these docs | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) |
+| The PyTorch-Wildlife framework, classifiers, demo notebooks | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) |
+| Ecosystem-wide questions and discussion | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) |
+
+## Reporting bugs and requesting features
+
+Open an issue on [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues). Helpful reports include the model variant and threshold you used, the command or code that triggered the problem, and a sample of the output. If you are reporting how MegaDetector performed on your data — good or bad — that feedback is genuinely useful for improving the models.
+
+## Submitting changes
+
+1. Fork the repository and create a branch for your change.
+2. Make your edits — for code, the [Repository Architecture](architecture.md) page explains the package layout; for docs, the [Developer Guide](build_mkdocs.md) covers building the site locally.
+3. Open a pull request describing the change and the motivation.
+
+Documentation improvements are welcome and are often the easiest first contribution.
+
+## Reporting security issues
+
+Please do **not** report security vulnerabilities through public GitHub issues. Follow the process in the repository's [SECURITY.md](https://github.com/microsoft/MegaDetector/blob/main/SECURITY.md), which routes reports to the Microsoft Security Response Center (MSRC).
+
+## Getting help
+
+- **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
+- **GitHub Discussions** — [microsoft/Biodiversity/discussions](https://github.com/microsoft/Biodiversity/discussions)
+- **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+
+## Next steps
+
+- [Repository Architecture](architecture.md) — orient yourself in the codebase
+- [Developer Guide](build_mkdocs.md) — build and preview the docs
+- [FAQ](faq.md) — common questions before you file an issue

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,6 +47,6 @@ Please do **not** report security vulnerabilities through public GitHub issues. 
 
 ## Next steps
 
-- [Repository Architecture](architecture.md), orient yourself in the codebase
-- [Developer Guide](build_mkdocs.md), build and preview the docs
-- [FAQ](faq.md), common questions before you file an issue
+- [Repository Architecture](architecture.md): orient yourself in the codebase
+- [Developer Guide](build_mkdocs.md): build and preview the docs
+- [FAQ](faq.md): common questions before you file an issue

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,6 +89,22 @@ For a graphical interface, use [SPARROW Studio](https://github.com/microsoft/SPA
 See [Installation](installation.md) for full setup instructions.
 
 
+## What is the `megadetector` CLI?
+
+`megadetector` is a command-line tool registered when you install the repository from source (`pip install -e .`). It runs the same V6 models without writing any Python:
+
+```bash
+megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e
+```
+
+It also exposes `train`, `validate`, and `inference` for fine-tuning. The full flag list and the supported `--model` values are in the [CLI reference](cli.md).
+
+
+## What does MegaDetector output look like?
+
+MegaDetector returns one record per image — a `file` path plus a list of `detections`, each carrying a `category` (`animal`, `person`, or `vehicle`), a `confidence` score from 0 to 1, and a `bbox` as `[x1, y1, x2, y2]` pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the [Output Format](output_format.md) reference for the full schema.
+
+
 ## What is the license?
 
 MegaDetector is released under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE). You can use it for any purpose, including commercial use, subject to the license terms.
@@ -128,3 +144,4 @@ See [Cite Us](cite.md) for full citation details and BibTeX.
 - **GitHub Issues:** [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) — bug reports and feature requests
 - **Discord:** [Join the PyTorch-Wildlife server](https://discord.gg/TeEVxzaYtm) — community support and discussion
 - **Email:** [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Contributing:** see the [contributing guide](contributing.md) — issue routing, pull requests, and security reporting

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
-description: "MegaDetector FAQ — frequently asked questions about installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to use MegaDetector for camera-trap wildlife detection."
+description: "MegaDetector FAQ, frequently asked questions about installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to use MegaDetector for camera-trap wildlife detection."
 tags:
   - MegaDetector FAQ
   - MegaDetector how to
@@ -15,7 +15,7 @@ tags:
 
 MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images. It draws bounding boxes around detected objects and assigns a confidence score between 0 and 1.
 
-MegaDetector is a **detector**, not a classifier — it tells you *something is there*, not what species it is. This design choice is intentional: a single detector generalizes across ecosystems far better than a species classifier, which is typically region-specific. For species identification, pair MegaDetector with a downstream classifier.
+MegaDetector is a **detector**, not a classifier, it tells you *something is there*, not what species it is. This design choice is intentional: a single detector generalizes across ecosystems far better than a species classifier, which is typically region-specific. For species identification, pair MegaDetector with a downstream classifier.
 
 
 ## What does MegaDetector detect?
@@ -24,7 +24,7 @@ MegaDetector detects three categories:
 
 | Category | Examples |
 |---|---|
-| Animal | Mammals, birds, reptiles, insects, fish — any wildlife |
+| Animal | Mammals, birds, reptiles, insects, fish, any wildlife |
 | Person | Researchers, poachers, tourists |
 | Vehicle | Cars, trucks, ATVs |
 
@@ -33,7 +33,7 @@ It does not identify species. An image containing a lion and a zebra returns two
 
 ## Do I need a GPU?
 
-No — MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets (tens of thousands of images or more), but is not required.
+No, MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets (tens of thousands of images or more), but is not required.
 
 The compact MegaDetectorV6 variants (YOLOv10-Compact, YOLOv9-Compact) are specifically designed for low-budget devices and edge hardware like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
 
@@ -43,9 +43,9 @@ The compact MegaDetectorV6 variants (YOLOv10-Compact, YOLOv9-Compact) are specif
 | | MegaDetectorV5 | MegaDetectorV6 |
 |---|---|---|
 | Architecture | YOLOv5 | YOLOv9, YOLOv10, RT-DETR (multiple variants) |
-| Parameters (compact) | 139.9M | 2.3M (YOLOv10-Compact — 2% of V5) |
+| Parameters (compact) | 139.9M | 2.3M (YOLOv10-Compact, 2% of V5) |
 | License | MIT | MIT |
-| Status | Maintained by Dan Morris at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) | Current release — recommended for new projects |
+| Status | Maintained by Dan Morris at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) | Current release, recommended for new projects |
 | Weights | Available on [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) | Download automatically via PyTorch-Wildlife |
 
 **Recommendation:** Use MegaDetectorV6 for new projects. MegaDetectorV5 remains available and is actively maintained by the community.
@@ -65,7 +65,7 @@ MegaDetector generalizes well across ecosystems because it was trained on a larg
 
 ## What species does MegaDetector support?
 
-All of them — with caveats. MegaDetector detects the presence of an animal, not the species. It has been deployed on projects involving African savanna megafauna, North American forest species, European ungulates, tropical insects, and marine wildlife.
+All of them, with caveats. MegaDetector detects the presence of an animal, not the species. It has been deployed on projects involving African savanna megafauna, North American forest species, European ungulates, tropical insects, and marine wildlife.
 
 Performance varies. Large mammals in open habitat are reliably detected. Very small animals, heavily camouflaged species, or unusual angles may have lower confidence scores. If you're working with an atypical dataset, we recommend testing on a labeled sample before full deployment.
 
@@ -102,19 +102,19 @@ It also exposes `train`, `validate`, and `inference` for fine-tuning. The full f
 
 ## What does MegaDetector output look like?
 
-MegaDetector returns one record per image — a `file` path plus a list of `detections`, each carrying a `category` (`animal`, `person`, or `vehicle`), a `confidence` score from 0 to 1, and a `bbox` as `[x1, y1, x2, y2]` pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the [Output Format](output_format.md) reference for the full schema.
+MegaDetector returns one record per image, a `file` path plus a list of `detections`, each carrying a `category` (`animal`, `person`, or `vehicle`), a `confidence` score from 0 to 1, and a `bbox` as `[x1, y1, x2, y2]` pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the [Output Format](output_format.md) reference for the full schema.
 
 
 ## What is the license?
 
 MegaDetector is released under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE). You can use it for any purpose, including commercial use, subject to the license terms.
 
-The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-licensed. Individual model weights may carry separate licenses — see the [Model Zoo](model_zoo.md) for per-model licensing information.
+The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-licensed. Individual model weights may carry separate licenses, see the [Model Zoo](model_zoo.md) for per-model licensing information.
 
 
 ## What is Dan Morris's fork?
 
-Dan Morris developed MegaDetector V1–V5 during his time at Microsoft. He continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which includes an extensive set of helper scripts, batch processing tools, and documentation accumulated over years of community use. It remains a valuable resource — especially for users of V5 weights or the original `run_detector_batch.py` workflow.
+Dan Morris developed MegaDetector V1–V5 during his time at Microsoft. He continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which includes an extensive set of helper scripts, batch processing tools, and documentation accumulated over years of community use. It remains a valuable resource, especially for users of V5 weights or the original `run_detector_batch.py` workflow.
 
 The `microsoft/MegaDetector` repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community.
 
@@ -141,7 +141,7 @@ See [Cite Us](cite.md) for full citation details and BibTeX.
 
 ## Where do I get help?
 
-- **GitHub Issues:** [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) — bug reports and feature requests
-- **Discord:** [Join the PyTorch-Wildlife server](https://discord.gg/TeEVxzaYtm) — community support and discussion
+- **GitHub Issues:** [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues), bug reports and feature requests
+- **Discord:** [Join the PyTorch-Wildlife server](https://discord.gg/TeEVxzaYtm), community support and discussion
 - **Email:** [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
-- **Contributing:** see the [contributing guide](contributing.md) — issue routing, pull requests, and security reporting
+- **Contributing:** see the [contributing guide](contributing.md), issue routing, pull requests, and security reporting

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,9 +13,9 @@ tags:
 
 ## What is MegaDetector?
 
-MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images. It draws bounding boxes around detected objects and assigns a confidence score between 0 and 1.
+MegaDetector is the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good)'s open-source model for finding animals, people, and vehicles in camera-trap images. It draws a bounding box around each detected object and gives it a confidence score between 0 and 1.
 
-MegaDetector is a **detector**, not a classifier, it tells you *something is there*, not what species it is. This design choice is intentional: a single detector generalizes across ecosystems far better than a species classifier, which is typically region-specific. For species identification, pair MegaDetector with a downstream classifier.
+It is a **detector**, not a classifier. It tells you *something is there*, not which species. That is a deliberate choice: one detector generalizes across ecosystems far better than a species classifier, which is usually region-specific. For species identification, pair MegaDetector with a downstream classifier.
 
 
 ## What does MegaDetector detect?
@@ -114,7 +114,7 @@ The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-license
 
 ## What is Dan Morris's fork?
 
-Dan Morris developed MegaDetector V1–V5 during his time at Microsoft. He continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which includes an extensive set of helper scripts, batch processing tools, and documentation accumulated over years of community use. It remains a valuable resource, especially for users of V5 weights or the original `run_detector_batch.py` workflow.
+Dan Morris built MegaDetector V1–V5 while at Microsoft, and now runs a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector). It bundles years of helper scripts, batch-processing tools, and documentation, and stays useful for V5 weights or the original `run_detector_batch.py` workflow.
 
 The `microsoft/MegaDetector` repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
-description: "MegaDetector FAQ, frequently asked questions about installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to use MegaDetector for camera-trap wildlife detection."
+description: "MegaDetector FAQ: installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to run MegaDetector for camera-trap wildlife detection."
 tags:
   - MegaDetector FAQ
   - MegaDetector how to

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,9 @@ tags:
 > [!TIP]
 > MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella, the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
 
-**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of sorting images.
+**Built by the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good), MegaDetector is an open-source model that locates animals, people, and vehicles in camera-trap images.** A typical camera deployment produces millions of frames, most of them empty. MegaDetector boxes whatever it finds and scores each box, so researchers can clear the blanks automatically and spend their time on science rather than sorting images.
 
-MegaDetector is an **animal detector**, not a species classifier. For species recognition, pair MegaDetector with a downstream classifier (see [Species classification](#species-classification) below). The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by more than 80 conservation organizations worldwide.
+MegaDetector is an **animal detector**, not a species classifier. For species recognition, pair MegaDetector with a downstream classifier (see [Species classification](#species-classification) below). It is free and open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and runs in more than 80 conservation programs worldwide.
 
 This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 
@@ -49,9 +49,9 @@ results = model.batch_image_detection("path/to/image_folder/")
 
 **Prefer not to install anything?**
 
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images and run MegaDetector in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), a free cloud GPU
-- [SPARROW Studio](https://github.com/microsoft/SPARROW), a full desktop application with a graphical interface
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images and run MegaDetector in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): a free cloud GPU
+- [SPARROW Studio](https://github.com/microsoft/SPARROW): a full desktop application with a graphical interface
 
 Full setup, including conda environments and GPU configuration, is on the [Installation](installation.md) page.
 
@@ -118,7 +118,7 @@ Throughput depends on the variant and your hardware:
 | Modern CPU (no GPU) | MDV6-yolov10-c (2.3M) | ~2–5 images/sec |
 | Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
 
-As a rule of thumb, at **50 images/sec on a GPU, one million images takes about 5.5 hours**; on CPU with the compact model, roughly 3.9 days. Every V6 variant is faster than the 139.9M-parameter V5.
+As a rule of thumb, at **50 images/sec on a GPU, one million images takes about 5.5 hours**; on CPU with the compact model, roughly 3.9 days. Even the heaviest V6 variant runs faster than V5.
 
 
 ## Is there a graphical interface?
@@ -181,7 +181,7 @@ The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetec
 
 For new projects, use V6. If you need V5 weights or earlier versions, they're on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-MegaDetector V1–V5 were primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with an extensive set of helper scripts and documentation, a valuable resource, especially for users of the V5 weights or the original `run_detector_batch.py` workflow. The two projects coexist: `microsoft/MegaDetector` carries V6 and future development.
+MegaDetector V1–V5 were primarily developed by **Dan Morris** while at Microsoft. He still maintains a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with a large set of helper scripts and documentation, handy if you work with the V5 weights or the original `run_detector_batch.py` workflow. The two projects run in parallel: `microsoft/MegaDetector` carries V6 and future development.
 
 
 ## Part of the Biodiversity ecosystem

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ tags:
 
 **MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty — triggered by wind or moving vegetation. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of clicking through images.
 
-MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by more than 80 conservation organizations worldwide.
+MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by conservation organizations worldwide.
 
 This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 
@@ -54,6 +54,8 @@ results = model.batch_image_detection("path/to/image_folder/")
 - [SPARROW Studio](https://github.com/microsoft/SPARROW) — a full desktop application with a graphical interface
 
 Full setup, including conda environments and GPU configuration, is on the [Installation](installation.md) page.
+
+Prefer the command line? The [CLI reference](cli.md) covers `megadetector detect`, and the [Output Format](output_format.md) guide explains the JSON results MegaDetector writes.
 
 
 ## What does MegaDetector detect?
@@ -170,7 +172,7 @@ It is not perfect. Very small animals, heavily camouflaged species, and unusual 
 
 ## Who uses MegaDetector?
 
-MegaDetector is used by 80+ government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection:
+MegaDetector is used by government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection of adopters named in the PyTorch-Wildlife list:
 
 - **Government** — Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada, U.S. Fish & Wildlife Service, National Park Service
 - **Conservation NGOs** — The Nature Conservancy, Island Conservation, Australian Wildlife Conservancy, RSPB
@@ -227,6 +229,7 @@ Full citation details and the PyTorch-Wildlife BibTeX are on the [Cite Us](cite.
 - **GitHub Issues** — [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) for bugs and feature requests
 - **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
 - **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Contributing** — see the [contributing guide](contributing.md); the [repository architecture](architecture.md) page explains the codebase layout
 
 > [!TIP]
 > New to MegaDetector? The [FAQ](faq.md) covers installation, accuracy, GPU requirements, V5 vs. V6, and licensing in one place.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: "MegaDetector — Open-Source Camera-Trap AI for Wildlife Detection"
-description: "MegaDetector is Microsoft AI for Good Lab's open-source model that detects animals, people, and vehicles in camera-trap images — faster and smaller in V6."
+title: "MegaDetector, Open-Source Camera-Trap AI for Wildlife Detection"
+description: "MegaDetector is Microsoft AI for Good Lab's open-source model that detects animals, people, and vehicles in camera-trap images, faster and smaller in V6."
 tags:
   - MegaDetector
   - MegaDetectorV6
@@ -17,18 +17,18 @@ tags:
 # MegaDetector
 
 > [!TIP]
-> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella — the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
+> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella, the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
 
-**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty — triggered by wind or moving vegetation. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of clicking through images.
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of sorting images.
 
-MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by conservation organizations worldwide.
+MegaDetector is an **animal detector**, not a species classifier. For species recognition, pair MegaDetector with a downstream classifier (see [Species classification](#species-classification) below). The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by more than 80 conservation organizations worldwide.
 
 This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 
 
 ## Quick start
 
-Install the package and run the model in three lines of Python — V6 weights download automatically the first time:
+Install the package and run the model in three lines of Python, V6 weights download automatically the first time:
 
 ```bash
 pip install PytorchWildlife
@@ -49,9 +49,9 @@ results = model.batch_image_detection("path/to/image_folder/")
 
 **Prefer not to install anything?**
 
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images and run MegaDetector in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — a free cloud GPU
-- [SPARROW Studio](https://github.com/microsoft/SPARROW) — a full desktop application with a graphical interface
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images and run MegaDetector in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), a free cloud GPU
+- [SPARROW Studio](https://github.com/microsoft/SPARROW), a full desktop application with a graphical interface
 
 Full setup, including conda environments and GPU configuration, is on the [Installation](installation.md) page.
 
@@ -60,22 +60,16 @@ Prefer the command line? The [CLI reference](cli.md) covers `megadetector detect
 
 ## What does MegaDetector detect?
 
-MegaDetector sorts everything in a frame into three categories:
+MegaDetector detects objects of interest into three categories: animals, people, and vehicles.
 
-| Category | What it covers |
-| --- | --- |
-| **Animal** | Mammals, birds, reptiles, insects, fish — any wildlife |
-| **Person** | Researchers, tourists, poachers |
-| **Vehicle** | Cars, trucks, ATVs |
-
-Each detection comes with a confidence score between 0 and 1. You choose a threshold — most projects use **0.15–0.3** for the animal category — and anything above it is flagged. The output is a standard results file you can sort by, filter blanks from, or feed into a species classifier. An image with a lion and a zebra returns two **animal** detections, not "lion" and "zebra"; naming the species is the classifier's job.
+Each detection comes with a confidence score between 0 and 1. You choose a threshold (e.g., **0.15–0.3** for the animal category) and anything above it is flagged. The output is a standard results file you can feed into downstream tasks such as species classification.
 
 
 ## MegaDetectorV6: smaller, faster, better
 
 MegaDetectorV6 is the sixth generation of the model, rebuilt around three goals: **computational efficiency, modern architectures, and licensing flexibility.** Instead of a single network, V6 ships a family of variants trained on **YOLOv9**, **YOLOv10**, and **RT-DETR**, so you can match the model to your hardware.
 
-The headline result: the compact YOLOv10 variant (`MDV6-yolov10-c`) carries just **2.3M parameters — about 2% of MegaDetectorV5's 139.9M** — while holding comparable accuracy on the lab's validation datasets. That makes it light enough to run on a laptop CPU or an edge device like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
+The headline result: the compact YOLOv10 variant (`MDV6-yolov10-c`) carries just **2.3M parameters, about 2% of MegaDetectorV5's 139.9M**, while holding comparable accuracy on the lab's validation datasets. That makes it light enough to run on a laptop CPU or an edge device like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
 
 A representative slice of the model family:
 
@@ -87,7 +81,7 @@ A representative slice of the model family:
 | MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
 
 > [!TIP]
-> This is a subset. The full nine-variant lineup — with YOLOv9, RT-DETR, and additional MIT/Apache options — is in the [Model Zoo](model_zoo.md). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
+> This is a subset. The full nine-variant lineup, with YOLOv9, RT-DETR, and additional MIT/Apache options, is in the [Model Zoo](model_zoo.md). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
 
 ```python
 from PytorchWildlife.models import detection as pw_detection
@@ -101,10 +95,10 @@ V6 models are continuously fine-tuned on newly collected public and private data
 
 ## Which model should I use?
 
-- **Best accuracy** — `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
-- **Best for laptops and edge devices** — `MDV6-yolov10-c` (2.3M params, runs on CPU)
-- **Best all-round balance** — `MDV6-yolov10-e` (29.5M params, 82.8% recall)
-- **Need an MIT-licensed model** — `MDV6-mit-yolov9-c`
+- **Best accuracy**, `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
+- **Best for laptops and edge devices**, `MDV6-yolov10-c` (2.3M params, runs on CPU)
+- **Best all-round balance**, `MDV6-yolov10-e` (29.5M params, 82.8% recall)
+- **Need an MIT-licensed model**, `MDV6-mit-yolov9-c`
 
 When in doubt, start with `MDV6-yolov10-e` and only switch if accuracy or hardware constraints push you toward a different variant.
 
@@ -129,16 +123,16 @@ As a rule of thumb, at **50 images/sec on a GPU, one million images takes about 
 
 ## Is there a graphical interface?
 
-Yes — you don't have to write any Python if you'd rather not:
+Yes, you don't have to write any Python if you'd rather not:
 
-- **[SPARROW Studio](https://github.com/microsoft/SPARROW)** — the AI for Good Lab's unified desktop app, built on PyTorch-Wildlife. Run MegaDetector and species classifiers through a GUI, manage data locally or in the cloud, and annotate and visualize results. A signed Windows installer is available [from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1); Mac and Linux builds are in progress.
-- **[AddaxAI](https://addaxdatascience.com/addaxai/)** (formerly EcoAssist) — a popular third-party desktop tool for running MegaDetector with batch processing, annotation, and visualization on Windows, macOS, and Linux.
-- **[Hugging Face Space](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife)** — run MegaDetector in your browser with nothing to install.
+- **[SPARROW Studio](https://github.com/microsoft/SPARROW)**, the AI for Good Lab's unified desktop app, built on PyTorch-Wildlife. Run MegaDetector and species classifiers through a GUI, manage data locally or in the cloud, and annotate and visualize results. A signed Windows installer is available [from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1); Mac and Linux builds are in progress.
+- **[AddaxAI](https://addaxdatascience.com/addaxai/)** (formerly EcoAssist), a popular third-party desktop tool for running MegaDetector with batch processing, annotation, and visualization on Windows, macOS, and Linux.
+- **[Hugging Face Space](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife)**, run MegaDetector in your browser with nothing to install.
 
 
 ## Species classification
 
-MegaDetector finds animals; it doesn't name them. To identify species, run a two-stage pipeline — MegaDetector localizes each animal, then a classifier labels the crop:
+To identify species, run a two-stage pipeline: 1) MegaDetector detects the animals, and 2) a classifier recognizes them:
 
 ```python
 import supervision as sv
@@ -156,29 +150,29 @@ for xyxy in det_results["detections"].xyxy:
     print(f"Species: {cls_result['prediction']}")
 ```
 
-PyTorch-Wildlife ships several regional classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, AI4G Opossum, DeepFaune, DFNE). Google's [SpeciesNet](https://github.com/google/cameratrapai), which covers roughly 2,000 species globally, is also designed to consume MegaDetector output.
+PyTorch-Wildlife ships several animal classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, AI4G Opossum, DeepFaune, DFNE). You can also run Google's [SpeciesNet](https://github.com/google/cameratrapai) through PyTorch-Wildlife; SpeciesNet covers roughly 2,000 species globally and is designed to consume MegaDetector output.
 
 
 ## How accurate is MegaDetector?
 
 Accuracy depends on your data and your confidence threshold, so the honest answer is always **test on your own images before trusting any number.** The compact V6 variants reach accuracy comparable to V5 at 2% of the parameter count on the lab's validation datasets, and the larger variants in the [Model Zoo](model_zoo.md) report animal recall above 82%.
 
-In practice, a threshold of **0.15–0.3** gives high recall (few missed animals) at the cost of some false positives on vegetation and lighting artifacts; raising it trims false positives but risks dropping low-confidence true detections. MegaDetector generalizes well across ecosystems because it was trained on a large, geographically diverse dataset — performance is strongest on large mammals in open habitat.
+In practice, a threshold of **0.15–0.3** gives high recall (few missed animals) at the cost of some false positives on vegetation and lighting artifacts; raising it trims false positives but risks dropping low-confidence true positives. MegaDetector generalizes well across ecosystems because it was trained on a large, geographically diverse dataset. Performance is strongest on large mammals in open habitat.
 
 ### Where MegaDetector struggles
 
-It is not perfect. Very small animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence scores and can be missed. If your dataset is atypical, label a small sample and measure recall before relying on the model at scale.
+MegaDetector struggles with small animals and reptiles. Unusual camera angles also tend to produce lower confidence scores and can be missed. If your dataset is atypical, label a small sample and measure recall before relying on the model at scale.
 
 
 ## Who uses MegaDetector?
 
-MegaDetector is used by government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection of adopters named in the PyTorch-Wildlife list:
+MegaDetector is used by more than 80 organizations worldwide, including government agencies, universities, NGOs, museums, and technology platforms. A selection:
 
-- **Government** — Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada, U.S. Fish & Wildlife Service, National Park Service
-- **Conservation NGOs** — The Nature Conservancy, Island Conservation, Australian Wildlife Conservancy, RSPB
-- **Universities** — UCLA, University of Washington, UBC, University of Florida, UNSW Sydney, Wildlife Institute of India
-- **Museums & zoos** — American Museum of Natural History, Smithsonian, San Diego Zoo Wildlife Alliance, Taronga Conservation Society
-- **Platforms** — TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network
+- **Government**, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada, U.S. Fish & Wildlife Service, National Park Service
+- **Conservation NGOs**, The Nature Conservancy, Island Conservation, Australian Wildlife Conservancy, RSPB
+- **Universities**, UCLA, University of Washington, UBC, University of Florida, UNSW Sydney, Wildlife Institute of India
+- **Museums & zoos**, American Museum of Natural History, Smithsonian, San Diego Zoo Wildlife Alliance, Taronga Conservation Society
+- **Platforms**, TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network
 
 The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) lives in the PyTorch-Wildlife repository.
 
@@ -187,7 +181,7 @@ The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetec
 
 For new projects, use V6. If you need V5 weights or earlier versions, they're on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-MegaDetector V1–V5 were primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with an extensive set of helper scripts and documentation — a valuable resource, especially for users of the V5 weights or the original `run_detector_batch.py` workflow. The two projects coexist: `microsoft/MegaDetector` carries V6 and future development.
+MegaDetector V1–V5 were primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with an extensive set of helper scripts and documentation, a valuable resource, especially for users of the V5 weights or the original `run_detector_batch.py` workflow. The two projects coexist: `microsoft/MegaDetector` carries V6 and future development.
 
 
 ## Part of the Biodiversity ecosystem
@@ -196,12 +190,12 @@ MegaDetector is one model in a larger open-source ecosystem from the AI for Good
 
 | Repo | Purpose |
 | --- | --- |
-| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
-| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal, person, and vehicle detection in camera-trap imagery |
+| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository, documentation hub for the AI for Good Lab's biodiversity work |
+| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project, animal, person, and vehicle detection in camera-trap imagery |
 | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
-| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
+| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch, the AI-enabled edge device that runs MegaDetector in the field |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
-| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and regions |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning, adapt classifiers to your own datasets and regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
 | SPARROW Studio | The desktop application that wraps it all in a graphical interface |
@@ -226,10 +220,10 @@ Full citation details and the PyTorch-Wildlife BibTeX are on the [Cite Us](cite.
 
 ## Get help
 
-- **GitHub Issues** — [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) for bugs and feature requests
-- **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
-- **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
-- **Contributing** — see the [contributing guide](contributing.md); the [repository architecture](architecture.md) page explains the codebase layout
+- **GitHub Issues**, [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) for bugs and feature requests
+- **Discord**, [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
+- **Email**, [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Contributing**, see the [contributing guide](contributing.md); the [repository architecture](architecture.md) page explains the codebase layout
 
 > [!TIP]
 > New to MegaDetector? The [FAQ](faq.md) covers installation, accuracy, GPU requirements, V5 vs. V6, and licensing in one place.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
-title: "MegaDetector: Open-Source Camera-Trap AI | Microsoft AI for Good"
-description: "MegaDetector: open-source AI model from Microsoft AI for Good Lab that detects animals, people, and vehicles in camera-trap images. Used by 80+ conservation organizations worldwide."
-schema: software
+title: "MegaDetector — Open-Source Camera-Trap AI for Wildlife Detection"
+description: "MegaDetector is Microsoft AI for Good Lab's open-source model that detects animals, people, and vehicles in camera-trap images — faster and smaller in V6."
 tags:
   - MegaDetector
   - MegaDetectorV6
@@ -11,50 +10,25 @@ tags:
   - conservation AI
   - PyTorch-Wildlife
   - Microsoft AI for Good
+  - YOLOv10
+  - RT-DETR
 ---
 
-# MegaDetector: Open-Source AI for Camera-Trap Wildlife Detection
+# MegaDetector
 
 > [!TIP]
 > MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella — the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
 
-**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals in camera-trap imagery.** Used by more than 80 conservation organizations worldwide, MegaDetector automates the review of camera-trap images so researchers can skip empty frames and focus on science. It does not identify species — it locates animals so they can be passed to a downstream classifier.
+**MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty — triggered by wind or moving vegetation. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of clicking through images.
 
-Our mission is to create a global community where conservation scientists can collaborate — sharing datasets and deep learning architectures for wildlife conservation. We're committed to supporting, maintaining, and advancing **MegaDetector** to ensure its continued **relevance, performance, and impact** for biodiversity research worldwide.
+MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by more than 80 conservation organizations worldwide.
 
-
-## Official Resources
-
-The canonical, up-to-date home for MegaDetector — start here, and link here:
-
-| Resource | Where |
-| --- | --- |
-| **Official documentation** | This site — [microsoft.github.io/MegaDetector](https://microsoft.github.io/MegaDetector/) |
-| **Source code & releases** | [microsoft/MegaDetector on GitHub](https://github.com/microsoft/MegaDetector) |
-| **Python framework** | [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) — hosts and distributes MegaDetectorV6 |
-| **Python package** | [`PytorchWildlife` on PyPI](https://pypi.org/project/PytorchWildlife/) — `pip install PytorchWildlife` |
-| **Legacy V5 tooling** | [Dan Morris community fork](https://github.com/agentmorris/MegaDetector) |
-| **MegaDetectorV5 weights** | [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive) (formerly `microsoft/CameraTraps`) |
+This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 
 
-## What is MegaDetector?
+## Quick start
 
-MegaDetector is a **detector**, not a species classifier: it draws a bounding box around each animal it finds and assigns a confidence score, telling you *something is there* rather than *what species it is*. That single design choice is why one model generalizes across ecosystems — from African savanna to North American forest to tropical insect surveys — far better than a region-specific classifier. For species identification, pair MegaDetector with a downstream classifier such as those in [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife). For the full breakdown of what MegaDetector locates in each frame, see the [MegaDetector FAQ](faq.md#what-does-megadetector-detect).
-
-
-## Why use MegaDetector for camera-trap images?
-
-Camera traps generate enormous volumes of imagery, and the majority of frames are empty — triggered by wind, rain, or moving vegetation. MegaDetector solves the triage problem:
-
-- **Filter empty frames** so reviewers only spend time on images that actually contain wildlife.
-- **Process large datasets** — run locally on CPU, on a CUDA GPU for a 10–50× speedup, or on low-budget edge hardware.
-- **Stay open source** — MIT-licensed, free for research and commercial use.
-- **Plug into an ecosystem** — graphical tools, notebooks, and field devices already speak MegaDetector.
-
-See the [camera-trap AI guide](camera-trap-ai.md) for how detection fits into a full review workflow.
-
-
-## Quick Start
+Install the package and run the model in three lines of Python — V6 weights download automatically the first time:
 
 ```bash
 pip install PytorchWildlife
@@ -63,113 +37,196 @@ pip install PytorchWildlife
 ```python
 from PytorchWildlife.models import detection as pw_detection
 
-# Load MegaDetector V6 (weights download automatically)
+# Load MegaDetectorV6 (weights download automatically)
 model = pw_detection.MegaDetectorV6()
 
-# Run on a single image
+# Detect in a single image
 results = model.single_image_detection("path/to/camera_trap_image.jpg")
 
-# Run on a folder of images
+# Detect across a whole folder
 results = model.batch_image_detection("path/to/image_folder/")
 ```
 
-**Try it without installing anything:**
+**Prefer not to install anything?**
 
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images and run MegaDetector in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — a free cloud GPU
+- [SPARROW Studio](https://github.com/microsoft/SPARROW) — a full desktop application with a graphical interface
+
+Full setup, including conda environments and GPU configuration, is on the [Installation](installation.md) page.
 
 
-## MegaDetectorV6: SMALLER, FASTER, BETTER
+## What does MegaDetector detect?
 
-We have officially released our 6th version of MegaDetector, **MegaDetectorV6**. In the next generation of MegaDetector, we focused on computational efficiency, performance, modernizing of model architectures, and licensing. We have trained multiple new models using different model architectures that are optimized for performance and low-budget devices, including **YOLOv9**, **YOLOv10**, and **RT-DETR** for maximum user flexibility.
+MegaDetector sorts everything in a frame into three categories:
 
-For example, the **MegaDetectorV6-Ultralytics-YoloV10-Compact** (`MDV6-yolov10-c`) model has only ***2% of the parameters*** of the previous MegaDetectorV5 (2.3M vs. 139.9M) and still exhibits comparable performance on our validation datasets.
+| Category | What it covers |
+| --- | --- |
+| **Animal** | Mammals, birds, reptiles, insects, fish — any wildlife |
+| **Person** | Researchers, tourists, poachers |
+| **Vehicle** | Cars, trucks, ATVs |
 
-To test the newest version of MegaDetector with all the existing functionalities, you can use our [Hugging Face interface](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) or load the model with **PyTorch-Wildlife** — weights download automatically:
+Each detection comes with a confidence score between 0 and 1. You choose a threshold — most projects use **0.15–0.3** for the animal category — and anything above it is flagged. The output is a standard results file you can sort by, filter blanks from, or feed into a species classifier. An image with a lion and a zebra returns two **animal** detections, not "lion" and "zebra"; naming the species is the classifier's job.
+
+
+## MegaDetectorV6: smaller, faster, better
+
+MegaDetectorV6 is the sixth generation of the model, rebuilt around three goals: **computational efficiency, modern architectures, and licensing flexibility.** Instead of a single network, V6 ships a family of variants trained on **YOLOv9**, **YOLOv10**, and **RT-DETR**, so you can match the model to your hardware.
+
+The headline result: the compact YOLOv10 variant (`MDV6-yolov10-c`) carries just **2.3M parameters — about 2% of MegaDetectorV5's 139.9M** — while holding comparable accuracy on the lab's validation datasets. That makes it light enough to run on a laptop CPU or an edge device like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
+
+A representative slice of the model family:
+
+| Model | Params | Animal recall | mAP50 | License |
+| --- | --- | --- | --- | --- |
+| MDV6-apa-rtdetr-e | 76M | 82.9% | 94.1% | Apache-2.0 |
+| MDV6-yolov10-e | 29.5M | 82.8% | 92.8% | AGPL-3.0 |
+| MDV6-yolov10-c | 2.3M | 76.8% | 87.2% | AGPL-3.0 |
+| MDV6-mit-yolov9-c | 9.7M | 74.8% | 87.6% | MIT |
+
+> [!TIP]
+> This is a subset. The full nine-variant lineup — with YOLOv9, RT-DETR, and additional MIT/Apache options — is in the [Model Zoo](model_zoo.md). Variant names are standardized as **MDV6-Compact** and **MDV6-Extra** for the two sizes within each architecture.
 
 ```python
 from PytorchWildlife.models import detection as pw_detection
-detection_model = pw_detection.MegaDetectorV6()
+
+# Load a specific variant
+model = pw_detection.MegaDetectorV6(version="MDV6-apa-rtdetr-e")
 ```
 
-> [!TIP]
-> All versions of MegaDetector and corresponding performance can be found in the [Model Zoo](model_zoo.md).
-
-We will continuously fine-tune our V6 models on newly collected public and private data to further improve generalization performance.
+V6 models are continuously fine-tuned on newly collected public and private data to keep improving how well they generalize to new environments.
 
 
-### Which MegaDetector version should I use?
+## Which model should I use?
 
-Use **MegaDetectorV6** for new projects — it is smaller, faster, and ships modern architectures (YOLOv9, YOLOv10, RT-DETR). Use **MegaDetectorV5** if you need the original V5 workflow, legacy scripts, or continuity with previously published results; it remains community-maintained by Dan Morris. See the [full V5-vs-V6 comparison in the FAQ](faq.md#what-is-the-difference-between-megadetectorv5-and-megadetectorv6) and per-variant benchmarks in the [MegaDetector model zoo](model_zoo.md).
+- **Best accuracy** — `MDV6-apa-rtdetr-e` (82.9% recall, Apache-2.0)
+- **Best for laptops and edge devices** — `MDV6-yolov10-c` (2.3M params, runs on CPU)
+- **Best all-round balance** — `MDV6-yolov10-e` (29.5M params, 82.8% recall)
+- **Need an MIT-licensed model** — `MDV6-mit-yolov9-c`
+
+When in doubt, start with `MDV6-yolov10-e` and only switch if accuracy or hardware constraints push you toward a different variant.
 
 
-## MegaDetectorV5 and Archive Repos
+## Do I need a GPU?
 
-For those interested in accessing the previous MegaDetector repository, which utilizes the same `MegaDetectorV5` model weights and was primarily developed by **Dan Morris** during his time at Microsoft, please visit the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`), or visit the [forked repository](https://github.com/agentmorris/MegaDetector/tree/main) that Dan Morris is currently actively maintaining.
+No. MegaDetector runs on a CPU. A CUDA-capable NVIDIA GPU delivers a **10–50× speedup** and is strongly recommended once you're processing tens of thousands of images, but it is not required to get started. The compact V6 variants are built specifically for low-budget and edge hardware, so a modern laptop is enough for many projects.
+
+### How fast is MegaDetector?
+
+Throughput depends on the variant and your hardware:
+
+| Hardware | Model | Approximate speed |
+| --- | --- | --- |
+| NVIDIA RTX 3090 | MDV6-yolov10-c (2.3M) | ~100–200 images/sec |
+| NVIDIA RTX 3090 | MDV6-yolov10-e (29.5M) | ~30–60 images/sec |
+| Modern CPU (no GPU) | MDV6-yolov10-c (2.3M) | ~2–5 images/sec |
+| Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
+
+As a rule of thumb, at **50 images/sec on a GPU, one million images takes about 5.5 hours**; on CPU with the compact model, roughly 3.9 days. Every V6 variant is faster than the 139.9M-parameter V5.
 
 
-## Use MegaDetector without code
+## Is there a graphical interface?
 
-Prefer a graphical workflow? MegaDetector runs inside several no-code tools:
+Yes — you don't have to write any Python if you'd rather not:
 
-- **[SPARROW Studio](https://github.com/microsoft/SPARROW)** — the desktop application that wraps the AI for Good Lab biodiversity stack in a graphical interface.
-- **[Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife)** — upload images in your browser, nothing to install.
-- **[Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing)** — free cloud GPU.
+- **[SPARROW Studio](https://github.com/microsoft/SPARROW)** — the AI for Good Lab's unified desktop app, built on PyTorch-Wildlife. Run MegaDetector and species classifiers through a GUI, manage data locally or in the cloud, and annotate and visualize results. A signed Windows installer is available [from Zenodo](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1); Mac and Linux builds are in progress.
+- **[AddaxAI](https://addaxdatascience.com/addaxai/)** (formerly EcoAssist) — a popular third-party desktop tool for running MegaDetector with batch processing, annotation, and visualization on Windows, macOS, and Linux.
+- **[Hugging Face Space](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife)** — run MegaDetector in your browser with nothing to install.
 
-See [camera-trap software](camera-trap-software.md) for the full landscape of desktop and web interfaces.
+
+## Species classification
+
+MegaDetector finds animals; it doesn't name them. To identify species, run a two-stage pipeline — MegaDetector localizes each animal, then a classifier labels the crop:
+
+```python
+import supervision as sv
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+
+detector = pw_detection.MegaDetectorV6()
+classifier = pw_classification.AI4GAmazonRainforest()
+
+det_results = detector.single_image_detection("image.jpg")
+
+for xyxy in det_results["detections"].xyxy:
+    cropped = sv.crop_image(image=det_results["img"], xyxy=xyxy)
+    cls_result = classifier.single_image_classification(cropped)
+    print(f"Species: {cls_result['prediction']}")
+```
+
+PyTorch-Wildlife ships several regional classifiers (AI4G Amazon Rainforest, AI4G Snapshot Serengeti, AI4G Opossum, DeepFaune, DFNE). Google's [SpeciesNet](https://github.com/google/cameratrapai), which covers roughly 2,000 species globally, is also designed to consume MegaDetector output.
+
+
+## How accurate is MegaDetector?
+
+Accuracy depends on your data and your confidence threshold, so the honest answer is always **test on your own images before trusting any number.** The compact V6 variants reach accuracy comparable to V5 at 2% of the parameter count on the lab's validation datasets, and the larger variants in the [Model Zoo](model_zoo.md) report animal recall above 82%.
+
+In practice, a threshold of **0.15–0.3** gives high recall (few missed animals) at the cost of some false positives on vegetation and lighting artifacts; raising it trims false positives but risks dropping low-confidence true detections. MegaDetector generalizes well across ecosystems because it was trained on a large, geographically diverse dataset — performance is strongest on large mammals in open habitat.
+
+### Where MegaDetector struggles
+
+It is not perfect. Very small animals, heavily camouflaged species, and unusual camera angles tend to produce lower confidence scores and can be missed. If your dataset is atypical, label a small sample and measure recall before relying on the model at scale.
 
 
 ## Who uses MegaDetector?
 
-MegaDetector is used by **more than 80 conservation organizations worldwide** — academic camera-trap labs, conservation NGOs, and government wildlife agencies — to triage biodiversity-monitoring imagery at scale, and it runs in the field on the solar-powered [SPARROW](https://github.com/microsoft/SPARROW) edge device. See the [project repository](https://github.com/microsoft/MegaDetector) for current deployments and collaborators.
+MegaDetector is used by 80+ government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection:
+
+- **Government** — Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada, U.S. Fish & Wildlife Service, National Park Service
+- **Conservation NGOs** — The Nature Conservancy, Island Conservation, Australian Wildlife Conservancy, RSPB
+- **Universities** — UCLA, University of Washington, UBC, University of Florida, UNSW Sydney, Wildlife Institute of India
+- **Museums & zoos** — American Museum of Natural History, Smithsonian, San Diego Zoo Wildlife Alliance, Taronga Conservation Society
+- **Platforms** — TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network
+
+The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) lives in the PyTorch-Wildlife repository.
 
 
-## MegaDetector in conservation research
+## MegaDetectorV5 and earlier
 
-MegaDetector has been used and evaluated in peer-reviewed camera-trap research on automated wildlife detection, blank-frame filtering, and large-scale monitoring workflows. The foundational references are:
+For new projects, use V6. If you need V5 weights or earlier versions, they're on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-- Beery, Morris, Yang (2019). *Efficient Pipeline for Camera Trap Image Review.* arXiv:1907.06772.
-- Hernandez et al. (2024). *Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation.* arXiv:2405.12930.
-
-See [Cite Us](cite.md) for full citation details and BibTeX.
+MegaDetector V1–V5 were primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with an extensive set of helper scripts and documentation — a valuable resource, especially for users of the V5 weights or the original `run_detector_batch.py` workflow. The two projects coexist: `microsoft/MegaDetector` carries V6 and future development.
 
 
-## MegaDetector licenses and model variants
+## Part of the Biodiversity ecosystem
 
-MegaDetector is released under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE) — free for research and commercial use. Individual V6 weights may carry their own terms depending on the backbone architecture; see the [MegaDetector model zoo](model_zoo.md) for per-variant licensing and the [FAQ](faq.md#what-is-the-license) for details.
-
-
-## Cite MegaDetector
-
-If MegaDetector supports your work, please cite it. A `CITATION.cff` in the repository powers GitHub's "Cite this repository" button and Zenodo. Full BibTeX for both the MegaDetector model and the PyTorch-Wildlife framework is on the [Cite Us](cite.md) page.
-
-
-## Frequently asked questions
-
-Common questions, answered in full on the [MegaDetector FAQ](faq.md):
-
-- [What does MegaDetector detect?](faq.md#what-does-megadetector-detect)
-- [Do I need a GPU?](faq.md#do-i-need-a-gpu)
-- [How accurate is MegaDetector?](faq.md#how-accurate-is-megadetector)
-- [What is the difference between MegaDetectorV5 and MegaDetectorV6?](faq.md#what-is-the-difference-between-megadetectorv5-and-megadetectorv6)
-- [What is the license?](faq.md#what-is-the-license)
-
-
-## Part of the Biodiversity Ecosystem
-
-MegaDetector is one project in a larger open-source ecosystem from the AI for Good Lab:
+MegaDetector is one model in a larger open-source ecosystem from the AI for Good Lab, with the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella tying it together:
 
 | Repo | Purpose |
 | --- | --- |
 | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
-| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal detection in camera-trap imagery |
+| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | This project — animal, person, and vehicle detection in camera-trap imagery |
 | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework hosting MegaDetector, species classifiers, and demo notebooks |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — the AI-enabled edge device that runs MegaDetector in the field |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
-| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection models for overhead and aerial imagery |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection for aquatic monitoring |
 | SPARROW Studio | The desktop application that wraps it all in a graphical interface |
 
+
+## Citing MegaDetector
+
+If MegaDetector contributed to your research, please cite the original model paper and, if you used the framework, PyTorch-Wildlife:
+
+```bibtex
+@misc{beery2019efficient,
+      title={Efficient Pipeline for Camera Trap Image Review},
+      author={Sara Beery and Dan Morris and Siyu Yang},
+      year={2019},
+      eprint={1907.06772},
+      archivePrefix={arXiv},
+}
+```
+
+Full citation details and the PyTorch-Wildlife BibTeX are on the [Cite Us](cite.md) page, or use GitHub's **"Cite this repository"** button on [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector).
+
+
+## Get help
+
+- **GitHub Issues** — [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) for bugs and feature requests
+- **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
+- **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+
 > [!TIP]
-> If you have any questions regarding MegaDetector and PyTorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our Discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PyTorch-Wildlife)](https://discord.gg/TeEVxzaYtm)
+> New to MegaDetector? The [FAQ](faq.md) covers installation, accuracy, GPU requirements, V5 vs. V6, and licensing in one place.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,12 +90,12 @@ Weights are downloaded automatically on first use.
 
 ## Try Without Installing
 
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), free cloud GPU
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): free cloud GPU
 
 
 ## Next Steps
 
-- [CLI Reference](cli.md), run detection from the command line
-- [Model Zoo](model_zoo.md), choose the right MDV6 variant for your hardware
-- [Training Guide](training_guide.md), fine-tune MegaDetector on your own data
+- [CLI Reference](cli.md): run detection from the command line
+- [Model Zoo](model_zoo.md): choose the right MDV6 variant for your hardware
+- [Training Guide](training_guide.md): fine-tune MegaDetector on your own data

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 ---
-description: "Install MegaDetector via PyTorch-Wildlife for camera-trap wildlife detection. Supports pip, conda, and Docker on Windows, macOS, and Linux with optional CUDA GPU acceleration."
+description: "Install MegaDetector via PyTorch-Wildlife for camera-trap detection: pip, conda, and Docker on Windows, macOS, and Linux, with optional CUDA GPU support."
 tags:
   - MegaDetector installation
   - pip install PytorchWildlife

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,35 @@ pip install PytorchWildlife
 ```
 
 
+## Install from Source (CLI and Fine-Tuning)
+
+To use the local `megadetector` command-line tool, or to fine-tune V6 weights on your own dataset, install this repository in editable mode:
+
+```bash
+git clone https://github.com/microsoft/MegaDetector
+cd MegaDetector
+pip install -e .
+```
+
+This installs the `megadetector_core` package and registers the `megadetector` command (`detect`, `train`, `validate`, `inference`). The `pyproject.toml` declares the full dependency set, so there is no separate `requirements.txt`.
+
+Prefer conda for a source install? The repository ships an `environment.yaml` you can build from directly:
+
+```bash
+conda env create -f environment.yaml
+conda activate megadetector
+pip install -e .
+```
+
+Confirm the CLI is on your path:
+
+```bash
+megadetector --help
+```
+
+See the [CLI reference](cli.md) for the full command surface, and the [Repository Architecture](architecture.md) for how the `megadetector_core` package is organized.
+
+
 ## Verify Installation
 
 ```python
@@ -67,5 +96,6 @@ Weights are downloaded automatically on first use.
 
 ## Next Steps
 
+- [CLI Reference](cli.md) — run detection from the command line
 - [Model Zoo](model_zoo.md) — choose the right MDV6 variant for your hardware
 - [Training Guide](training_guide.md) — fine-tune MegaDetector on your own data

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,12 +90,12 @@ Weights are downloaded automatically on first use.
 
 ## Try Without Installing
 
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing), free cloud GPU
 
 
 ## Next Steps
 
-- [CLI Reference](cli.md) — run detection from the command line
-- [Model Zoo](model_zoo.md) — choose the right MDV6 variant for your hardware
-- [Training Guide](training_guide.md) — fine-tune MegaDetector on your own data
+- [CLI Reference](cli.md), run detection from the command line
+- [Model Zoo](model_zoo.md), choose the right MDV6 variant for your hardware
+- [Training Guide](training_guide.md), fine-tune MegaDetector on your own data

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -24,9 +24,9 @@ The latest release focuses on **efficiency**, **modern architectures**, and **li
 ### Highlights
 
 - **50x smaller**: The compact YOLOv10 variant has **2.3M parameters**, 2% of MegaDetectorV5's 139.9M, with comparable accuracy
-- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR, pick the one that fits your hardware
+- **Multiple architectures**: YOLOv9, YOLOv10, and RT-DETR for different hardware budgets
 - **Permissive licenses**: MIT and Apache-2.0 options alongside AGPL-3.0
-- **Ongoing fine-tuning**: V6 models are continuously fine-tuned on newly collected public and private data
+- **Ongoing fine-tuning**: V6 weights are refreshed as new public and private data arrives
 
 ### Model Variants
 
@@ -102,4 +102,4 @@ At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU 
 
 For MegaDetectorV5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-The original MegaDetector repository was primarily developed by **Dan Morris** during his time at Microsoft. Dan continues to actively maintain a forked version at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which remains a valuable resource for the community.
+MegaDetector V1–V5 came from **Dan Morris** at Microsoft; his community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) is still widely used.

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -19,12 +19,12 @@ All MegaDetector model variants with performance metrics, parameter counts, and 
 
 ## MegaDetector V6 (Current)
 
-The latest release focuses on **efficiency**, **modern architectures**, and **licensing flexibility** — **SMALLER, FASTER, BETTER**.
+The latest release focuses on **efficiency**, **modern architectures**, and **licensing flexibility**, **SMALLER, FASTER, BETTER**.
 
 ### Highlights
 
-- **50x smaller**: The compact YOLOv10 variant has **2.3M parameters** — 2% of MegaDetectorV5's 139.9M — with comparable accuracy
-- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR — pick the one that fits your hardware
+- **50x smaller**: The compact YOLOv10 variant has **2.3M parameters**, 2% of MegaDetectorV5's 139.9M, with comparable accuracy
+- **Multiple architectures**: YOLOv9, YOLOv10, RT-DETR, pick the one that fits your hardware
 - **Permissive licenses**: MIT and Apache-2.0 options alongside AGPL-3.0
 - **Ongoing fine-tuning**: V6 models are continuously fine-tuned on newly collected public and private data
 
@@ -65,7 +65,7 @@ V6 deliberately offers variants under three licenses so you can match the model 
 
 | License | Variants | Use when |
 | --- | --- | --- |
-| **MIT** | `MDV6-mit-yolov9-c`, `MDV6-mit-yolov9-e` | You need a permissive license with no copyleft obligations — e.g. bundling weights into a closed-source product |
+| **MIT** | `MDV6-mit-yolov9-c`, `MDV6-mit-yolov9-e` | You need a permissive license with no copyleft obligations, e.g. bundling weights into a closed-source product |
 | **Apache-2.0** | `MDV6-apa-rtdetr-c`, `MDV6-apa-rtdetr-e` | You want a permissive license with an explicit patent grant; `MDV6-apa-rtdetr-e` is also the top-accuracy variant |
 | **AGPL-3.0** | the remaining YOLOv9/YOLOv10/RT-DETR variants | Your use is compatible with strong copyleft (research, internal tools, AGPL-licensed services) |
 
@@ -93,9 +93,9 @@ At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU 
 | --- | --- | --- | --- | --- |
 | **V6.0** (current) | 2024 | YOLOv9/v10, RT-DETR | 2.3M–76M | Multiple variants, MIT/Apache options |
 | V5.0 | 2022 | YOLOv5 | 139.9M | Two sub-versions (5a, 5b) |
-| V4.1 | 2020 | Faster R-CNN | — | Added vehicle class |
-| V3 | 2019 | Faster R-CNN | — | Added human class |
-| V2 | 2018 | Faster R-CNN | — | First public release |
+| V4.1 | 2020 | Faster R-CNN |, | Added vehicle class |
+| V3 | 2019 | Faster R-CNN |, | Added human class |
+| V2 | 2018 | Faster R-CNN |, | First public release |
 
 
 ## MegaDetector V5 and Earlier

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -1,5 +1,5 @@
 ---
-description: "MegaDetector model zoo: all MegaDetectorV6 variants with architectures, parameter counts, animal recall, mAP50, and license options for camera-trap wildlife detection."
+description: "MegaDetector model zoo: all MegaDetectorV6 variants with architectures, parameter counts, animal recall, mAP50, and license options for camera traps."
 tags:
   - MegaDetector
   - MegaDetectorV6

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -59,6 +59,22 @@ model = pw_detection.MegaDetectorV6(version="MDV6-apa-rtdetr-e")
 ```
 
 
+## Model Licensing
+
+V6 deliberately offers variants under three licenses so you can match the model to your project's distribution requirements:
+
+| License | Variants | Use when |
+| --- | --- | --- |
+| **MIT** | `MDV6-mit-yolov9-c`, `MDV6-mit-yolov9-e` | You need a permissive license with no copyleft obligations — e.g. bundling weights into a closed-source product |
+| **Apache-2.0** | `MDV6-apa-rtdetr-c`, `MDV6-apa-rtdetr-e` | You want a permissive license with an explicit patent grant; `MDV6-apa-rtdetr-e` is also the top-accuracy variant |
+| **AGPL-3.0** | the remaining YOLOv9/YOLOv10/RT-DETR variants | Your use is compatible with strong copyleft (research, internal tools, AGPL-licensed services) |
+
+The repository **code** is MIT-licensed independently of the weights. Always confirm the license of the specific variant you ship.
+
+> [!NOTE]
+> The [`megadetector` CLI](cli.md) selects from the AGPL YOLOv9/YOLOv10/RT-DETR variants via `--model`; the MIT and Apache variants are loaded through the PyTorch-Wildlife Python API.
+
+
 ## Performance Benchmarks
 
 | Hardware | Model | Approximate Speed |

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -1,0 +1,66 @@
+---
+title: "MegaDetector Output Format — detection JSON schema"
+description: "MegaDetector output format: the JSON schema for detection results — file path, category, confidence score, and bounding box — and how to use it downstream."
+tags:
+  - megadetector output json
+  - detection schema
+  - bounding box format
+  - camera trap AI
+  - megadetector results
+---
+
+# Output Format
+
+MegaDetector writes its results as JSON. Whether you run the [`megadetector` CLI](cli.md) or the Python API, the structure is the same: a list of per-image records, each holding the image path and the objects detected in it.
+
+## Schema
+
+The top level is a JSON **list**. Each element describes one image:
+
+```json
+[
+  {
+    "file": "images/IMG_0001.jpg",
+    "detections": [
+      { "category": "animal",  "confidence": 0.93, "bbox": [102.4, 88.1, 540.7, 470.2] },
+      { "category": "person",  "confidence": 0.81, "bbox": [12.0, 40.5, 96.3, 510.9] }
+    ]
+  },
+  {
+    "file": "images/IMG_0002.jpg",
+    "detections": []
+  }
+]
+```
+
+An image with no detections above the threshold has an empty `detections` list — that is how blank frames are represented.
+
+## Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `file` | string | Path to the image, as supplied to the detector |
+| `detections` | list | One object per detection kept above the threshold (empty if none) |
+| `detections[].category` | string | `animal`, `person`, or `vehicle` |
+| `detections[].confidence` | float | Detection confidence from 0 to 1, rounded to 4 decimals |
+| `detections[].bbox` | list of 4 floats | Bounding box as `[x1, y1, x2, y2]` (top-left and bottom-right pixel coordinates), rounded to 1 decimal |
+
+The category names map from the model's class IDs: `0 → animal`, `1 → person`, `2 → vehicle`.
+
+## Thresholding
+
+Only detections whose confidence is greater than or equal to your chosen threshold are written; everything below is dropped. The CLI default is `0.2`, and most projects tune within `0.15–0.3` for the animal category. Lowering the threshold favors recall (fewer missed animals) at the cost of more false positives; raising it does the reverse.
+
+## Using the output
+
+The JSON is designed to flow straight into the rest of a camera-trap workflow:
+
+- **Review** — import it into a tool such as Timelapse to verify and annotate detections (see [Camera-Trap Software](camera-trap-software.md)).
+- **Filter** — drop images whose `detections` list is empty to clear blank frames in bulk.
+- **Classify** — crop each `bbox` and pass it to a species classifier (see the two-stage pipeline in the [FAQ](faq.md)).
+
+## Next steps
+
+- [CLI reference](cli.md) — the `detect` command that produces this JSON
+- [Camera-Trap Software](camera-trap-software.md) — review and analysis tools that consume it
+- [Model Zoo](model_zoo.md) — choose the variant that produced your detections

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -61,6 +61,6 @@ The JSON is designed to flow straight into the rest of a camera-trap workflow:
 
 ## Next steps
 
-- [CLI reference](cli.md), the `detect` command that produces this JSON
-- [Camera-Trap Software](camera-trap-software.md), review and analysis tools that consume it
-- [Model Zoo](model_zoo.md), choose the variant that produced your detections
+- [CLI reference](cli.md): the `detect` command that produces this JSON
+- [Camera-Trap Software](camera-trap-software.md): review and analysis tools that consume it
+- [Model Zoo](model_zoo.md): choose the variant that produced your detections

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -1,6 +1,6 @@
 ---
-title: "MegaDetector Output Format — detection JSON schema"
-description: "MegaDetector output format: the JSON schema for detection results — file path, category, confidence score, and bounding box — and how to use it downstream."
+title: "MegaDetector Output Format, detection JSON schema"
+description: "MegaDetector output format: the JSON schema for detection results, file path, category, confidence score, and bounding box, and how to use it downstream."
 tags:
   - megadetector output json
   - detection schema
@@ -33,7 +33,7 @@ The top level is a JSON **list**. Each element describes one image:
 ]
 ```
 
-An image with no detections above the threshold has an empty `detections` list — that is how blank frames are represented.
+An image with no detections above the threshold has an empty `detections` list, that is how blank frames are represented.
 
 ## Fields
 
@@ -55,12 +55,12 @@ Only detections whose confidence is greater than or equal to your chosen thresho
 
 The JSON is designed to flow straight into the rest of a camera-trap workflow:
 
-- **Review** — import it into a tool such as Timelapse to verify and annotate detections (see [Camera-Trap Software](camera-trap-software.md)).
-- **Filter** — drop images whose `detections` list is empty to clear blank frames in bulk.
-- **Classify** — crop each `bbox` and pass it to a species classifier (see the two-stage pipeline in the [FAQ](faq.md)).
+- **Review**, import it into a tool such as Timelapse to verify and annotate detections (see [Camera-Trap Software](camera-trap-software.md)).
+- **Filter**, drop images whose `detections` list is empty to clear blank frames in bulk.
+- **Classify**, crop each `bbox` and pass it to a species classifier (see the two-stage pipeline in the [FAQ](faq.md)).
 
 ## Next steps
 
-- [CLI reference](cli.md) — the `detect` command that produces this JSON
-- [Camera-Trap Software](camera-trap-software.md) — review and analysis tools that consume it
-- [Model Zoo](model_zoo.md) — choose the variant that produced your detections
+- [CLI reference](cli.md), the `detect` command that produces this JSON
+- [Camera-Trap Software](camera-trap-software.md), review and analysis tools that consume it
+- [Model Zoo](model_zoo.md), choose the variant that produced your detections

--- a/docs/training_guide.md
+++ b/docs/training_guide.md
@@ -1,5 +1,5 @@
 ---
-description: "MegaDetector fine-tuning guide: train custom detection models using MegaDetectorV6 architectures (YOLOv9, YOLOv10, RT-DETR) with the ultralytics framework for wildlife detection."
+description: "MegaDetector fine-tuning guide: train custom MegaDetectorV6 detection models (YOLOv9, YOLOv10, RT-DETR) on your own camera-trap wildlife data."
 tags:
   - MegaDetector fine-tuning
   - MegaDetectorV6

--- a/docs/training_guide.md
+++ b/docs/training_guide.md
@@ -14,7 +14,7 @@ tags:
 
 ← Back to [main README](https://github.com/microsoft/MegaDetector/blob/main/README.md).
 > [!TIP]
-> This guide covers fine-tuning MegaDetectorV6 models on your own data. For general inference usage, see the [Overview](index.md) and [Model Zoo](model_zoo.md).
+> This guide covers fine-tuning MegaDetectorV6 models on your own data. For general inference usage, see the [Overview](index.md) and [Model Zoo](model_zoo.md); for the `train`/`validate`/`inference` command surface used below, see the [CLI reference](cli.md), and for how the training code is organized, the [Repository Architecture](architecture.md).
 
 This guide covers training and fine-tuning detection models for MegaDetector using the ultralytics framework. This module is designed to help both programmers and biologists train a detection model for animal identification. The output weights of this training process can be easily integrated with MegaDetector inference.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,14 +74,19 @@ nav:
     - Overview: index.md
     - Installation: installation.md
     - Model Zoo: model_zoo.md
+    - CLI: cli.md
+    - Output Format: output_format.md
     - FAQ: faq.md
     - Tags: tags.md
   - Guides:
     - Camera-Trap AI: camera-trap-ai.md
     - Camera-Trap Software: camera-trap-software.md
     - Training Guide: training_guide.md
+  - Contributing: contributing.md
   - Cite Us: cite.md
-  - Developer Guide: build_mkdocs.md
+  - Developer Guide:
+    - Build the Docs: build_mkdocs.md
+    - Repository Architecture: architecture.md
 
 markdown_extensions:
   - admonition

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -68,7 +68,7 @@
         "name": "What is MegaDetector?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetector is an open-source AI model from the Microsoft AI for Good Lab that detects animals, people, and vehicles in camera-trap images. It is a detector, not a classifier — it tells you something is there, not what species it is. For species identification, pair MegaDetector with a downstream classifier."
+          "text": "MegaDetector is the Microsoft AI for Good Lab's open-source model for finding animals, people, and vehicles in camera-trap images. It draws a bounding box around each detected object and gives it a confidence score between 0 and 1. It is a detector, not a classifier: it tells you something is there, not which species. One detector generalizes across ecosystems far better than a region-specific species classifier. For species identification, pair MegaDetector with a downstream classifier."
         }
       },
       {
@@ -76,7 +76,7 @@
         "name": "What does MegaDetector detect?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetector detects three categories: animal, person, and vehicle. It does not identify species — an image containing a lion and a zebra returns two animal detections, not lion and zebra."
+          "text": "MegaDetector detects three categories: animal (mammals, birds, reptiles, insects, fish, any wildlife), person (researchers, poachers, tourists), and vehicle (cars, trucks, ATVs). It does not identify species. An image containing a lion and a zebra returns two animal detections, not lion and zebra."
         }
       },
       {
@@ -84,7 +84,7 @@
         "name": "Do I need a GPU?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "No — MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets, but is not required. Compact MegaDetectorV6 variants are designed for low-budget devices and edge hardware."
+          "text": "No, MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets (tens of thousands of images or more), but is not required. The compact MegaDetectorV6 variants (YOLOv10-Compact, YOLOv9-Compact) are specifically designed for low-budget devices and edge hardware like the SPARROW field unit."
         }
       },
       {
@@ -92,7 +92,47 @@
         "name": "What is the difference between MegaDetectorV5 and MegaDetectorV6?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetectorV5 uses the YOLOv5 architecture (139.9M parameters). MegaDetectorV6 uses modern architectures (YOLOv9, YOLOv10, RT-DETR) with compact variants as small as 2.3M parameters. Use MegaDetectorV6 for new projects; MegaDetectorV5 remains community-maintained by Dan Morris."
+          "text": "MegaDetectorV5 uses the YOLOv5 architecture with 139.9M parameters. MegaDetectorV6 uses modern architectures (YOLOv9, YOLOv10, RT-DETR) with compact variants as small as 2.3M parameters, about 2% of V5. Both are MIT-licensed. Use MegaDetectorV6 for new projects; MegaDetectorV5 remains available and is actively maintained by Dan Morris."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How accurate is MegaDetector?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Accuracy depends on the dataset and confidence threshold. MegaDetectorV6 compact variants achieve comparable accuracy to V5 at 2% of the parameter count on the AI for Good Lab's validation datasets. Most deployments use a confidence threshold of 0.15–0.3 for the animal category, which provides high recall at the cost of some false positives on vegetation and lighting artifacts. MegaDetector generalizes well across ecosystems because it was trained on a large and geographically diverse dataset, and performance is typically strongest on large mammals."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What species does MegaDetector support?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "All of them, with caveats. MegaDetector detects the presence of an animal, not the species. It has been deployed on projects involving African savanna megafauna, North American forest species, European ungulates, tropical insects, and marine wildlife. Large mammals in open habitat are reliably detected, while very small animals, heavily camouflaged species, or unusual angles may have lower confidence scores. Test on a labeled sample before full deployment on an atypical dataset."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I run MegaDetector?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The quickest path is three lines of Python: install PytorchWildlife with pip, import the detection module, create a MegaDetectorV6 model, and call batch_image_detection on an image folder. For a graphical interface, use SPARROW Studio or the Hugging Face demo. See the Installation guide for full setup instructions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the megadetector CLI?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "megadetector is a command-line tool registered when you install the repository from source with pip install -e. It runs the same V6 models without writing any Python, for example: megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e. It also exposes train, validate, and inference for fine-tuning. The full flag list and supported --model values are in the CLI reference."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What does MegaDetector output look like?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetector returns one record per image: a file path plus a list of detections, each carrying a category (animal, person, or vehicle), a confidence score from 0 to 1, and a bbox as [x1, y1, x2, y2] pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the Output Format reference for the full schema."
         }
       },
       {
@@ -100,7 +140,39 @@
         "name": "What is the license?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetector is released under the MIT License — free for any purpose including commercial use, subject to the license terms. The PyTorch-Wildlife framework that distributes it is also MIT-licensed; individual model weights may carry separate licenses."
+          "text": "MegaDetector is released under the MIT License. You can use it for any purpose, including commercial use, subject to the license terms. The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-licensed. Individual model weights may carry separate licenses; see the Model Zoo for per-model licensing information."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is Dan Morris's fork?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Dan Morris built MegaDetector V1–V5 while at Microsoft and now runs a community fork at agentmorris/MegaDetector. It bundles years of helper scripts, batch-processing tools, and documentation, and stays useful for V5 weights or the original run_detector_batch.py workflow. The microsoft/MegaDetector repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where are the V5 weights?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "MegaDetectorV5 weights are available on the archive branch of the microsoft/Biodiversity repository (formerly microsoft/CameraTraps). Dan Morris's fork at agentmorris/MegaDetector also hosts V5 and provides extensive tooling around it."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I cite MegaDetector?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A CITATION.cff is maintained in this repository for automated citation tools such as Zenodo and GitHub's Cite this repository button. For MegaDetector, cite Beery, Morris, Yang (2019), Efficient Pipeline for Camera Trap Image Review, arXiv:1907.06772. For the PyTorch-Wildlife framework, cite Hernandez et al. (2024), Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation, arXiv:2405.12930. See Cite Us for full citation details and BibTeX."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where do I get help?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Get help through GitHub Issues at microsoft/MegaDetector/issues for bug reports and feature requests, the PyTorch-Wildlife Discord server for community support, or email zhongqimiao@microsoft.com. For contributions, see the contributing guide covering issue routing, pull requests, and security reporting."
         }
       }
     ]


### PR DESCRIPTION
## Summary

SEO + content-depth pass for the MegaDetector README and docs site. This integration branch consolidates four reviewed sub-PRs (C1–C4) plus a repo-metadata fix. Goal: make the official Microsoft repo the most comprehensive, original, SERP-optimized MegaDetector resource — every fact sourced from this repo, nothing copied from any other project.

## Sub-PRs merged into this branch
| Phase | PR | Scope |
|---|---|---|
| C1 | (here) | README correctness — 3 detection classes (animals/people/vehicles), model table incl. MIT/Apache variants, license fix, "Which repo should I use?", soften unsourced "80+" claim |
| C2 | #23 | README depth — run paths (Python/CLI/no-code), output schema, accuracy, threshold, limitations, GPU, camera-trap software ecosystem |
| C3 | #24 | New docs pages — `cli.md`, `output_format.md`, `architecture.md`, `contributing.md` + nav |
| C4 | #25 | Deepen installation/faq/model_zoo/index/training_guide; finalize SEO front-matter + internal-link graph |

Plus: GitHub repo description updated to the 3-class / V6 line. Issue #22 opened to track the duplicate `src/megadetector_ai` package (canonical: `megadetector_core`).

## Verification (sanitized report)
| Gate | Result |
|---|---|
| README body words | **2,672 = 1.21×** the reference README (gate ≥1.20×) |
| README sections | **24** vs reference 9 (+167%) |
| docs/*.md total | **7,531** words (+38%) |
| Shared 10-grams vs combined reference (README + user guide) | **0** |
| Empty-alt images | **0** |
| `mkdocs build --strict` | **exit 0** (sitemap + canonical generated) |
| Inbound links per new page | ≥3 |

Residual shared 8-grams are allowlisted only (product descriptor, the Beery-2019 citation title, AddaxAI, microsoft.com URLs) — no copied prose. Full methodology + reusable check live in the team workspace.

## Constraints honored
Repo-data-only · zero copying · CLI model-support accuracy (5 CLI variants documented; MIT/Apache noted as PyTorch-Wildlife-only) · no webmaster-tool/origin-level actions (we don't own the Pages property).

## Notes for review
- Nothing reaches the live Pages site until this PR merges to `main`.
- The README org list has an `APPROVED-EXTERNAL` insertion point awaiting the reviewed adopter list.
