### PR TITLE
docs(C3): add CLI, Output Format, Architecture, and Contributing pages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+---
+title: "MegaDetector Repository Architecture"
+description: "How the MegaDetector repository is organized: the megadetector_core package, the megadetector CLI entry point, model wrappers, and the fine-tuning pipeline."
+tags:
+  - megadetector repo structure
+  - megadetector_core
+  - package layout
+  - megadetector architecture
+  - contributing
+---
+
+# Repository Architecture
+
+This page orients contributors and integrators to how the `microsoft/MegaDetector` repository is laid out and how its pieces fit together.
+
+## Package and entry point
+
+The installable package is **`megadetector-core`**, with its source under `src/megadetector_core/`. Installing the repository registers a single console command:
+
+```
+megadetector = "megadetector_core.cli:main"
+```
+
+So `megadetector detect …` on the command line maps to `main()` in `megadetector_core/cli.py`. The package metadata, dependencies, and entry point all live in `pyproject.toml`; there is no separate `requirements.txt`.
+
+## Source layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/megadetector_core/cli.py` | Argument parsing and the `detect`, `train`, `validate`, and `inference` subcommands |
+| `src/megadetector_core/detector.py` | Thin wrappers around PyTorch-Wildlife's `MegaDetectorV6` (and `MegaDetectorV5` for backward compatibility) |
+| `src/megadetector_core/training.py` | Config-driven fine-tuning, validation, and inference, delegating to the underlying training framework |
+| `src/megadetector_core/training_utils.py` | Resolves and caches model weights, downloading them when they are not already present |
+| `examples/config_training.yaml` | Reference fine-tuning config you copy and edit |
+| `environment.yaml` | Conda environment definition for setup from source |
+
+## How it relates to PyTorch-Wildlife
+
+MegaDetector models are served through the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. The wrappers in `detector.py` instantiate PyTorch-Wildlife's `MegaDetectorV6`, so the CLI, the Python API, and PyTorch-Wildlife all run the same weights. Model files are downloaded on first use and cached locally, so no weights are committed to this repository.
+
+## The fine-tuning path
+
+`megadetector train|validate|inference` each read a YAML config that points at your dataset and hyperparameters, then call into `training.py`. Outputs (weights, plots, metrics) are written under `./runs/`, and a fine-tuned `.pt` file can be loaded straight back into `MegaDetectorV6(weights="path/to/best.pt")`. The full schema and data layout are documented in the [Training Guide](training_guide.md).
+
+## Documentation
+
+The documentation site is built with MkDocs Material from the `docs/` directory. To build or preview it locally, see the [Developer Guide](build_mkdocs.md).
+
+## Next steps
+
+- [Contributing & Support](contributing.md) — how to file issues and submit changes
+- [CLI reference](cli.md) — the commands exposed by `megadetector_core`
+- [Training Guide](training_guide.md) — fine-tune a V6 model on your own data

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,85 @@
+---
+title: "MegaDetector CLI — detect, train, validate, inference"
+description: "MegaDetector CLI reference: run detection on camera-trap images with the megadetector detect command, plus train, validate, and inference subcommands."
+tags:
+  - megadetector cli
+  - megadetector detect
+  - command line
+  - batch detection
+  - camera trap AI
+---
+
+# MegaDetector CLI
+
+The `megadetector` command-line tool runs MegaDetector on a single image or a whole folder without writing any Python. It ships with the editable install of this repository and wraps the same V6 models exposed by the Python API.
+
+## Install the CLI
+
+The CLI is registered when you install the repository from source:
+
+```bash
+git clone https://github.com/microsoft/MegaDetector
+cd MegaDetector
+pip install -e .
+```
+
+This installs the `megadetector_core` package and the `megadetector` command. Verify it:
+
+```bash
+megadetector --help
+```
+
+## Detect
+
+`megadetector detect` is the command you will use most. It accepts either a single image or a directory (scanned recursively for `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, and `.tiff` files).
+
+```bash
+# Single image, print results to the terminal
+megadetector detect --input photo.jpg
+
+# A folder, write results to JSON, pick a model and threshold
+megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e --threshold 0.2
+
+# Force CPU
+megadetector detect --input ./images/ --device cpu
+```
+
+### Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--input`, `-i` | *(required)* | Path to an image file or a directory of images |
+| `--output`, `-o` | *(stdout)* | Path to write JSON results; prints to the terminal if omitted |
+| `--model`, `-m` | `MDV6-yolov9-c` | Model variant (see supported list below) |
+| `--threshold`, `-t` | `0.2` | Minimum confidence to keep a detection |
+| `--device`, `-d` | *(auto)* | `cuda:0`, `cpu`, or `mps`; auto-detects a GPU if omitted |
+
+### Supported models
+
+The `--model` flag accepts five V6 variants:
+
+`MDV6-yolov9-c`, `MDV6-yolov9-e`, `MDV6-yolov10-c`, `MDV6-yolov10-e`, and `MDV6-rtdetr-c`.
+
+The MIT and Apache-2.0 variants documented in the [Model Zoo](model_zoo.md) (for example `MDV6-apa-rtdetr-e`) are loaded through the PyTorch-Wildlife Python API rather than the CLI's `--model` flag.
+
+### What you get back
+
+The command writes a JSON list — one entry per image, each with a `file` path and a list of `detections`. When it finishes, it also prints a one-line summary: how many images were processed, the total number of detections, and how many images contain at least one animal. See the [Output Format](output_format.md) reference for the full schema.
+
+## Fine-tuning subcommands
+
+The same CLI drives the fine-tuning workflow, each subcommand reading a YAML config:
+
+```bash
+megadetector train    --config ./config.yaml
+megadetector validate --config ./config.yaml
+megadetector inference --config ./config.yaml
+```
+
+`--config` defaults to `./config.yaml`. For the data layout, the full config schema, and the Python API equivalents, see the [Training Guide](training_guide.md).
+
+## Next steps
+
+- [Output Format](output_format.md) — interpret the JSON MegaDetector produces
+- [Model Zoo](model_zoo.md) — every variant, with recall, mAP50, and license
+- [Installation](installation.md) — environment setup and GPU configuration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,52 @@
+---
+title: "Contributing to MegaDetector & Getting Support"
+description: "How to contribute to MegaDetector and get help: filing issues, submitting pull requests, reporting security concerns, and reaching the community."
+tags:
+  - contribute to megadetector
+  - megadetector support
+  - report a bug
+  - megadetector community
+  - security
+---
+
+# Contributing & Support
+
+MegaDetector is open source and community-driven. This page explains where to file things, how to contribute changes, and how to get help.
+
+## Where does my issue belong?
+
+The MegaDetector ecosystem spans a few repositories, so routing your report to the right place gets it answered faster:
+
+| Your topic | Repository |
+| --- | --- |
+| MegaDetector models, the CLI, fine-tuning, these docs | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) |
+| The PyTorch-Wildlife framework, classifiers, demo notebooks | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) |
+| Ecosystem-wide questions and discussion | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) |
+
+## Reporting bugs and requesting features
+
+Open an issue on [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues). Helpful reports include the model variant and threshold you used, the command or code that triggered the problem, and a sample of the output. If you are reporting how MegaDetector performed on your data — good or bad — that feedback is genuinely useful for improving the models.
+
+## Submitting changes
+
+1. Fork the repository and create a branch for your change.
+2. Make your edits — for code, the [Repository Architecture](architecture.md) page explains the package layout; for docs, the [Developer Guide](build_mkdocs.md) covers building the site locally.
+3. Open a pull request describing the change and the motivation.
+
+Documentation improvements are welcome and are often the easiest first contribution.
+
+## Reporting security issues
+
+Please do **not** report security vulnerabilities through public GitHub issues. Follow the process in the repository's [SECURITY.md](https://github.com/microsoft/MegaDetector/blob/main/SECURITY.md), which routes reports to the Microsoft Security Response Center (MSRC).
+
+## Getting help
+
+- **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
+- **GitHub Discussions** — [microsoft/Biodiversity/discussions](https://github.com/microsoft/Biodiversity/discussions)
+- **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+
+## Next steps
+
+- [Repository Architecture](architecture.md) — orient yourself in the codebase
+- [Developer Guide](build_mkdocs.md) — build and preview the docs
+- [FAQ](faq.md) — common questions before you file an issue

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -1,0 +1,66 @@
+---
+title: "MegaDetector Output Format — detection JSON schema"
+description: "MegaDetector output format: the JSON schema for detection results — file path, category, confidence score, and bounding box — and how to use it downstream."
+tags:
+  - megadetector output json
+  - detection schema
+  - bounding box format
+  - camera trap AI
+  - megadetector results
+---
+
+# Output Format
+
+MegaDetector writes its results as JSON. Whether you run the [`megadetector` CLI](cli.md) or the Python API, the structure is the same: a list of per-image records, each holding the image path and the objects detected in it.
+
+## Schema
+
+The top level is a JSON **list**. Each element describes one image:
+
+```json
+[
+  {
+    "file": "images/IMG_0001.jpg",
+    "detections": [
+      { "category": "animal",  "confidence": 0.93, "bbox": [102.4, 88.1, 540.7, 470.2] },
+      { "category": "person",  "confidence": 0.81, "bbox": [12.0, 40.5, 96.3, 510.9] }
+    ]
+  },
+  {
+    "file": "images/IMG_0002.jpg",
+    "detections": []
+  }
+]
+```
+
+An image with no detections above the threshold has an empty `detections` list — that is how blank frames are represented.
+
+## Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `file` | string | Path to the image, as supplied to the detector |
+| `detections` | list | One object per detection kept above the threshold (empty if none) |
+| `detections[].category` | string | `animal`, `person`, or `vehicle` |
+| `detections[].confidence` | float | Detection confidence from 0 to 1, rounded to 4 decimals |
+| `detections[].bbox` | list of 4 floats | Bounding box as `[x1, y1, x2, y2]` (top-left and bottom-right pixel coordinates), rounded to 1 decimal |
+
+The category names map from the model's class IDs: `0 → animal`, `1 → person`, `2 → vehicle`.
+
+## Thresholding
+
+Only detections whose confidence is greater than or equal to your chosen threshold are written; everything below is dropped. The CLI default is `0.2`, and most projects tune within `0.15–0.3` for the animal category. Lowering the threshold favors recall (fewer missed animals) at the cost of more false positives; raising it does the reverse.
+
+## Using the output
+
+The JSON is designed to flow straight into the rest of a camera-trap workflow:
+
+- **Review** — import it into a tool such as Timelapse to verify and annotate detections (see [Camera-Trap Software](camera-trap-software.md)).
+- **Filter** — drop images whose `detections` list is empty to clear blank frames in bulk.
+- **Classify** — crop each `bbox` and pass it to a species classifier (see the two-stage pipeline in the [FAQ](faq.md)).
+
+## Next steps
+
+- [CLI reference](cli.md) — the `detect` command that produces this JSON
+- [Camera-Trap Software](camera-trap-software.md) — review and analysis tools that consume it
+- [Model Zoo](model_zoo.md) — choose the variant that produced your detections

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,14 +74,19 @@ nav:
     - Overview: index.md
     - Installation: installation.md
     - Model Zoo: model_zoo.md
+    - CLI: cli.md
+    - Output Format: output_format.md
     - FAQ: faq.md
     - Tags: tags.md
   - Guides:
     - Camera-Trap AI: camera-trap-ai.md
     - Camera-Trap Software: camera-trap-software.md
     - Training Guide: training_guide.md
+  - Contributing: contributing.md
   - Cite Us: cite.md
-  - Developer Guide: build_mkdocs.md
+  - Developer Guide:
+    - Build the Docs: build_mkdocs.md
+    - Repository Architecture: architecture.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Part of the SEO/content-depth pass. Merges into `seo/megadetector-overview-rewrite` (PR #21 → main).

## New pages (all repo-sourced; zero reference content)
| Page | Covers | Source |
|---|---|---|
| `docs/cli.md` | `megadetector detect/train/validate/inference`, flags, supported `--model` list | `megadetector_core/cli.py` |
| `docs/output_format.md` | Detection JSON schema (file / category / confidence / bbox), thresholding, downstream use | `cli.py` |
| `docs/architecture.md` | `megadetector_core` package layout, entry point, model wrappers, fine-tuning path | `pyproject.toml`, `detector.py`, `training.py` |
| `docs/contributing.md` | Issue routing, PRs, MSRC security, community channels | `SECURITY.md`, README |

All four are wired into `mkdocs.yml` nav and cross-linked (also surfaces the previously orphaned camera-trap guides).

## Gates
- `mkdocs build --strict` — **exit 0** (nav + all internal links resolve; sitemap + canonical generated).
- Originality — new pages (1,392 words): **0 shared 8-grams and 0 shared 10-grams** with the reference.
- Each page carries SEO front-matter (keyword-first `description` + `tags`).