### PR TITLE
docs(C4): deepen existing docs + SEO front-matter + internal-link graph

### DIFF
--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -34,7 +34,7 @@ Most practitioners combine tools from more than one layer. MegaDetector sits in 
 **Access:** [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) — open-source, MIT license  
 **Ecosystem:** Part of [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife)
 
-MegaDetector detects animals, people, and vehicles in camera-trap images. It does not classify species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
+MegaDetector detects animals, people, and vehicles in camera-trap images, but does not classify them to species. Its primary function is to compress large image datasets before human review — removing blank frames and surfacing images that contain animals.
 
 ```python
 from PytorchWildlife.models import detection as pw_detection

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,6 +89,22 @@ For a graphical interface, use [SPARROW Studio](https://github.com/microsoft/SPA
 See [Installation](installation.md) for full setup instructions.
 
 
+## What is the `megadetector` CLI?
+
+`megadetector` is a command-line tool registered when you install the repository from source (`pip install -e .`). It runs the same V6 models without writing any Python:
+
+```bash
+megadetector detect --input ./images/ --output results.json --model MDV6-yolov10-e
+```
+
+It also exposes `train`, `validate`, and `inference` for fine-tuning. The full flag list and the supported `--model` values are in the [CLI reference](cli.md).
+
+
+## What does MegaDetector output look like?
+
+MegaDetector returns one record per image — a `file` path plus a list of `detections`, each carrying a `category` (`animal`, `person`, or `vehicle`), a `confidence` score from 0 to 1, and a `bbox` as `[x1, y1, x2, y2]` pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the [Output Format](output_format.md) reference for the full schema.
+
+
 ## What is the license?
 
 MegaDetector is released under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE). You can use it for any purpose, including commercial use, subject to the license terms.
@@ -128,3 +144,4 @@ See [Cite Us](cite.md) for full citation details and BibTeX.
 - **GitHub Issues:** [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) — bug reports and feature requests
 - **Discord:** [Join the PyTorch-Wildlife server](https://discord.gg/TeEVxzaYtm) — community support and discussion
 - **Email:** [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Contributing:** see the [contributing guide](contributing.md) — issue routing, pull requests, and security reporting

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ tags:
 
 **MegaDetector is an open-source AI model from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) that detects animals, people, and vehicles in camera-trap images.** Camera traps generate millions of frames, and most are empty — triggered by wind or moving vegetation. MegaDetector draws a bounding box around every animal, person, or vehicle it finds and assigns a confidence score, so researchers can filter blank frames automatically and spend their time on science instead of clicking through images.
 
-MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by more than 80 conservation organizations worldwide.
+MegaDetector is deliberately a **detector**, not a species classifier: "something is here" generalizes across ecosystems far better than "this is a specific species." For species identification, pair MegaDetector with a downstream classifier — see [Species classification](#species-classification) below. The model is free, open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and used by conservation organizations worldwide.
 
 This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 
@@ -54,6 +54,8 @@ results = model.batch_image_detection("path/to/image_folder/")
 - [SPARROW Studio](https://github.com/microsoft/SPARROW) — a full desktop application with a graphical interface
 
 Full setup, including conda environments and GPU configuration, is on the [Installation](installation.md) page.
+
+Prefer the command line? The [CLI reference](cli.md) covers `megadetector detect`, and the [Output Format](output_format.md) guide explains the JSON results MegaDetector writes.
 
 
 ## What does MegaDetector detect?
@@ -170,7 +172,7 @@ It is not perfect. Very small animals, heavily camouflaged species, and unusual 
 
 ## Who uses MegaDetector?
 
-MegaDetector is used by 80+ government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection:
+MegaDetector is used by government agencies, universities, NGOs, museums, and technology platforms worldwide. A selection of adopters named in the PyTorch-Wildlife list:
 
 - **Government** — Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada, U.S. Fish & Wildlife Service, National Park Service
 - **Conservation NGOs** — The Nature Conservancy, Island Conservation, Australian Wildlife Conservancy, RSPB
@@ -227,6 +229,7 @@ Full citation details and the PyTorch-Wildlife BibTeX are on the [Cite Us](cite.
 - **GitHub Issues** — [microsoft/MegaDetector/issues](https://github.com/microsoft/MegaDetector/issues) for bugs and feature requests
 - **Discord** — [join the PyTorch-Wildlife community](https://discord.gg/TeEVxzaYtm)
 - **Email** — [zhongqimiao@microsoft.com](mailto:zhongqimiao@microsoft.com)
+- **Contributing** — see the [contributing guide](contributing.md); the [repository architecture](architecture.md) page explains the codebase layout
 
 > [!TIP]
 > New to MegaDetector? The [FAQ](faq.md) covers installation, accuracy, GPU requirements, V5 vs. V6, and licensing in one place.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,35 @@ pip install PytorchWildlife
 ```
 
 
+## Install from Source (CLI and Fine-Tuning)
+
+To use the local `megadetector` command-line tool, or to fine-tune V6 weights on your own dataset, install this repository in editable mode:
+
+```bash
+git clone https://github.com/microsoft/MegaDetector
+cd MegaDetector
+pip install -e .
+```
+
+This installs the `megadetector_core` package and registers the `megadetector` command (`detect`, `train`, `validate`, `inference`). The `pyproject.toml` declares the full dependency set, so there is no separate `requirements.txt`.
+
+Prefer conda for a source install? The repository ships an `environment.yaml` you can build from directly:
+
+```bash
+conda env create -f environment.yaml
+conda activate megadetector
+pip install -e .
+```
+
+Confirm the CLI is on your path:
+
+```bash
+megadetector --help
+```
+
+See the [CLI reference](cli.md) for the full command surface, and the [Repository Architecture](architecture.md) for how the `megadetector_core` package is organized.
+
+
 ## Verify Installation
 
 ```python
@@ -67,5 +96,6 @@ Weights are downloaded automatically on first use.
 
 ## Next Steps
 
+- [CLI Reference](cli.md) — run detection from the command line
 - [Model Zoo](model_zoo.md) — choose the right MDV6 variant for your hardware
 - [Training Guide](training_guide.md) — fine-tune MegaDetector on your own data

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -59,6 +59,22 @@ model = pw_detection.MegaDetectorV6(version="MDV6-apa-rtdetr-e")
 ```
 
 
+## Model Licensing
+
+V6 deliberately offers variants under three licenses so you can match the model to your project's distribution requirements:
+
+| License | Variants | Use when |
+| --- | --- | --- |
+| **MIT** | `MDV6-mit-yolov9-c`, `MDV6-mit-yolov9-e` | You need a permissive license with no copyleft obligations — e.g. bundling weights into a closed-source product |
+| **Apache-2.0** | `MDV6-apa-rtdetr-c`, `MDV6-apa-rtdetr-e` | You want a permissive license with an explicit patent grant; `MDV6-apa-rtdetr-e` is also the top-accuracy variant |
+| **AGPL-3.0** | the remaining YOLOv9/YOLOv10/RT-DETR variants | Your use is compatible with strong copyleft (research, internal tools, AGPL-licensed services) |
+
+The repository **code** is MIT-licensed independently of the weights. Always confirm the license of the specific variant you ship.
+
+> [!NOTE]
+> The [`megadetector` CLI](cli.md) selects from the AGPL YOLOv9/YOLOv10/RT-DETR variants via `--model`; the MIT and Apache variants are loaded through the PyTorch-Wildlife Python API.
+
+
 ## Performance Benchmarks
 
 | Hardware | Model | Approximate Speed |

--- a/docs/training_guide.md
+++ b/docs/training_guide.md
@@ -14,7 +14,7 @@ tags:
 
 ← Back to [main README](https://github.com/microsoft/MegaDetector/blob/main/README.md).
 > [!TIP]
-> This guide covers fine-tuning MegaDetectorV6 models on your own data. For general inference usage, see the [Overview](index.md) and [Model Zoo](model_zoo.md).
+> This guide covers fine-tuning MegaDetectorV6 models on your own data. For general inference usage, see the [Overview](index.md) and [Model Zoo](model_zoo.md); for the `train`/`validate`/`inference` command surface used below, see the [CLI reference](cli.md), and for how the training code is organized, the [Repository Architecture](architecture.md).
 
 This guide covers training and fine-tuning detection models for MegaDetector using the ultralytics framework. This module is designed to help both programmers and biologists train a detection model for animal identification. The output weights of this training process can be easily integrated with MegaDetector inference.
 


### PR DESCRIPTION
Part of the SEO/content-depth pass. Merges into `seo/megadetector-overview-rewrite` (PR #21 → main).

## What this deepens (all facts repo-sourced)
- **installation.md** — new *Install from Source (CLI & Fine-Tuning)* section: editable install, `environment.yaml`, `megadetector` command.
- **faq.md** — adds *What is the megadetector CLI?* and *What does MegaDetector output look like?*; links the contributing guide.
- **model_zoo.md** — new *Model Licensing* section (MIT / Apache-2.0 / AGPL-3.0 picker) + CLI-support note.
- **index.md** — CLI/output cross-links; softens the unsourced "80+" org claims to repo-traceable wording; links contributing + architecture.
- **training_guide.md** — cross-links the CLI reference and Repository Architecture.
- **camera-trap-software.md** — one-line reword to remove a structural overlap.

## Gates
- `mkdocs build --strict` — **exit 0**.
- Internal-link graph: each of the four new pages (cli, output_format, architecture, contributing) now has **≥3 inbound links**.
- Originality: **0 shared 10-grams** across the full docs set vs. the combined reference (README + megadetector.md guide); remaining 8-grams are only the product descriptor, the Beery-2019 citation title, AddaxAI, and microsoft.com URLs.
- SEO front-matter (description + tags) present on every content page.