### PR TITLE
docs: long-tail SEO content, fork-link minimization, front-matter titles, last-updated dates

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so git-revision-date-localized can read commit dates
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")
 
 Use **this repository (`microsoft/MegaDetector`)** for MegaDetector V6: the current models, the [Model Zoo](https://microsoft.github.io/MegaDetector/model_zoo/), the fine-tuning pipeline, and the [documentation site](https://microsoft.github.io/MegaDetector/). It is the official home maintained by the Microsoft AI for Good Lab.
 
-If you are maintaining a legacy V5 workflow, the original models and tooling remain available: V5 weights live on the [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive), and project founder **Dan Morris** keeps the original tooling alive in a fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) full of V5-era helper scripts. For new projects, start with V6 here.
+If you are maintaining a legacy V5 workflow, the original models remain available: V5 weights live on the [Biodiversity archive branch](https://github.com/microsoft/Biodiversity/tree/archive) and load directly through PyTorch-Wildlife. For new projects, start with V6 here.
 
 
 ## Installation
@@ -371,7 +371,7 @@ API equivalents of each CLI subcommand.
 
 For MegaDetectorV5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-MegaDetector V1–V5 were primarily built by **Dan Morris** at Microsoft. He now maintains the [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) fork, which many V5 users still rely on.
+MegaDetector V1–V5 were originally developed by **Dan Morris** at Microsoft. The V5 weights load directly through PyTorch-Wildlife, so existing V5 workflows keep running.
 
 
 ## Our Commitment

--- a/docs/build_mkdocs.md
+++ b/docs/build_mkdocs.md
@@ -1,4 +1,5 @@
 ---
+title: "Build the MegaDetector Docs Site (MkDocs)"
 description: "How to build and deploy the MegaDetector MkDocs documentation site locally and to GitHub Pages."
 tags:
   - MegaDetector

--- a/docs/camera-trap-ai.md
+++ b/docs/camera-trap-ai.md
@@ -1,4 +1,5 @@
 ---
+title: "Camera-Trap AI Explained: Detection, Blank Filtering, and Classification"
 description: "Camera-trap AI explained: how machine learning automates wildlife monitoring, why detection matters for conservation, and where MegaDetector fits."
 tags:
   - camera trap AI
@@ -31,6 +32,10 @@ AI-based tools automate the most time-consuming parts of image review:
 
 **Tracking and counting** link detections across multiple images in a sequence, supporting population estimates, behavioral analysis, and occupancy modeling.
 
+### Filtering blank camera-trap images
+
+In a MegaDetector workflow, blank filtering is the first and highest-value step. You run the model over every image, keep the frames with a detection above your threshold, and route the rest to a blank pile. On a dataset that is mostly empty, this one pass can shrink the human review queue by roughly an order of magnitude before anyone opens an image.
+
 
 ## Detection vs. Classification, Why MegaDetector Is a Detector
 
@@ -43,6 +48,10 @@ This is not a limitation. It is a design choice with significant practical advan
 **Lower annotation cost.** Training a detector requires bounding-box annotations labeled as "animal," "person," or "vehicle." Training a species classifier requires those same bounding boxes labeled with species identity, which requires expert taxonomic knowledge for every species in every geographic region. Detector training is far cheaper to scale.
 
 **Cleaner workflow.** Separating detection from classification gives researchers control over each step. You can swap classifiers, tune thresholds independently, or skip classification entirely when species ID is not needed.
+
+### Species classification with MegaDetector
+
+MegaDetector stops at "animal, person, or vehicle" and does not name the species. To get species, add a classifier as a second stage that reads each MegaDetector box. PyTorch-Wildlife ships several such classifiers, and [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) lets you fine-tune one for your own region.
 
 The result is a two-stage workflow now adopted by more than 80 conservation organizations around the world:
 

--- a/docs/camera-trap-software.md
+++ b/docs/camera-trap-software.md
@@ -1,5 +1,6 @@
 ---
-description: "Camera-trap software overview: how MegaDetector fits alongside EcoAssist, Timelapse2, Wildlife Insights, and CamtrapR in the wildlife monitoring stack."
+title: "Camera-Trap Software Comparison: MegaDetector, EcoAssist, Wildlife Insights"
+description: "Camera-trap software comparison: how MegaDetector compares to EcoAssist, AddaxAI, Wildlife Insights, Timelapse2, and CamtrapR for camera-trap image analysis."
 tags:
   - camera trap software
   - camera trap image analysis software

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,4 +1,5 @@
 ---
+title: "Cite MegaDetector and PyTorch-Wildlife (BibTeX)"
 description: "How to cite MegaDetector and PyTorch-Wildlife in research, with BibTeX for the MegaDetector model (Beery 2019) and the framework (Hernandez 2024)."
 tags:
   - MegaDetector citation

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,5 @@
 ---
+title: "MegaDetector FAQ: Accuracy, GPU, Licensing, and V5 vs V6"
 description: "MegaDetector FAQ: installation, accuracy, GPU requirements, V5 vs V6, licensing, and how to run MegaDetector for camera-trap wildlife detection."
 tags:
   - MegaDetector FAQ
@@ -31,6 +32,11 @@ MegaDetector detects three categories:
 It does not identify species. An image containing a lion and a zebra returns two "animal" detections, not "lion" and "zebra."
 
 
+## How do I filter blank camera-trap images?
+
+Run MegaDetector across your image folder and keep only the frames that have an animal, person, or vehicle detection above your confidence threshold. Everything below the threshold is a blank you can set aside. Since most camera-trap datasets are mostly empty, this one pass clears the bulk of the review queue before any human looks at an image. The [Camera-Trap AI](camera-trap-ai.md) page walks through the blank-filtering workflow step by step.
+
+
 ## Do I need a GPU?
 
 No, MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup and is strongly recommended for large datasets (tens of thousands of images or more), but is not required.
@@ -38,17 +44,17 @@ No, MegaDetector runs on CPU. A GPU with CUDA support gives a 10–50x speedup a
 The compact MegaDetectorV6 variants (YOLOv10-Compact, YOLOv9-Compact) are specifically designed for low-budget devices and edge hardware like the [SPARROW](https://github.com/microsoft/SPARROW) field unit.
 
 
-## What is the difference between MegaDetectorV5 and MegaDetectorV6?
+## MegaDetector V6 vs V5: what's the difference?
 
 | | MegaDetectorV5 | MegaDetectorV6 |
 |---|---|---|
 | Architecture | YOLOv5 | YOLOv9, YOLOv10, RT-DETR (multiple variants) |
 | Parameters (compact) | 139.9M | 2.3M (YOLOv10-Compact, 2% of V5) |
 | License | MIT | MIT |
-| Status | Maintained by Dan Morris at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) | Current release, recommended for new projects |
+| Status | Legacy, still usable for existing workflows | Current release, recommended for new projects |
 | Weights | Available on [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) | Download automatically via PyTorch-Wildlife |
 
-**Recommendation:** Use MegaDetectorV6 for new projects. MegaDetectorV5 remains available and is actively maintained by the community.
+**Recommendation:** Use MegaDetectorV6 for new projects. MegaDetectorV5 weights remain available on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) for projects already built around them.
 
 > [!TIP]
 > For detailed model variants and benchmark results, see the [Model Zoo](model_zoo.md).
@@ -61,6 +67,11 @@ Accuracy depends on the dataset and confidence threshold. MegaDetectorV6 compact
 In practice, most deployments use a confidence threshold of 0.15–0.3 for the "animal" category, which provides high recall (few missed animals) at the cost of some false positives on vegetation and lighting artifacts. Setting the threshold higher reduces false positives but risks missing low-confidence true detections.
 
 MegaDetector generalizes well across ecosystems because it was trained on a large and geographically diverse dataset. Performance is typically strongest on large mammals and degrades on very small or camouflaged animals.
+
+
+## What confidence threshold should I use?
+
+A starting value of 0.15–0.3 on the animal category works for most datasets. That range favors recall, so you keep most true animals while accepting some false positives on moving vegetation and lighting artifacts. Raise it when a clean set matters more than catching every animal; lower it when a missed animal costs more than a few extra frames to review. When you move to a new deployment, check recall against a small labeled set first.
 
 
 ## What species does MegaDetector support?
@@ -100,6 +111,11 @@ megadetector detect --input ./images/ --output results.json --model MDV6-yolov10
 It also exposes `train`, `validate`, and `inference` for fine-tuning. The full flag list and the supported `--model` values are in the [CLI reference](cli.md).
 
 
+## Can I fine-tune MegaDetector on my own data?
+
+Yes. MegaDetectorV6 ships a training pipeline for fine-tuning the YOLOv9, YOLOv10, and RT-DETR variants on your own labeled camera-trap images, which helps when your species or habitats are thin in the base model. The [fine-tuning guide](training_guide.md) covers the data layout, the configuration file, and the `megadetector train` command from start to finish.
+
+
 ## What does MegaDetector output look like?
 
 MegaDetector returns one record per image, a `file` path plus a list of `detections`, each carrying a `category` (`animal`, `person`, or `vehicle`), a `confidence` score from 0 to 1, and a `bbox` as `[x1, y1, x2, y2]` pixel coordinates. Detections below your threshold are dropped, and the JSON feeds straight into review tools or a species classifier. See the [Output Format](output_format.md) reference for the full schema.
@@ -112,16 +128,9 @@ MegaDetector is released under the [MIT License](https://github.com/microsoft/Me
 The PyTorch-Wildlife framework that distributes MegaDetector is also MIT-licensed. Individual model weights may carry separate licenses, see the [Model Zoo](model_zoo.md) for per-model licensing information.
 
 
-## What is Dan Morris's fork?
-
-Dan Morris built MegaDetector V1–V5 while at Microsoft, and now runs a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector). It bundles years of helper scripts, batch-processing tools, and documentation, and stays useful for V5 weights or the original `run_detector_batch.py` workflow.
-
-The `microsoft/MegaDetector` repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community.
-
-
 ## Where are the V5 weights?
 
-MegaDetectorV5 weights are available on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the `microsoft/Biodiversity` repository (formerly `microsoft/CameraTraps`). Dan Morris's fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) also hosts V5 and provides extensive tooling around it.
+MegaDetectorV5 weights are available on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the `microsoft/Biodiversity` repository (formerly `microsoft/CameraTraps`). They load directly through PyTorch-Wildlife, so existing V5 workflows keep running without changes.
 
 
 ## How do I cite MegaDetector?

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,7 +181,7 @@ The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetec
 
 For new projects, use V6. If you need V5 weights or earlier versions, they're on the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-MegaDetector V1–V5 were primarily developed by **Dan Morris** while at Microsoft. He still maintains a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) with a large set of helper scripts and documentation, handy if you work with the V5 weights or the original `run_detector_batch.py` workflow. The two projects run in parallel: `microsoft/MegaDetector` carries V6 and future development.
+MegaDetector V1–V5 were originally developed by **Dan Morris** while at Microsoft. The V5 weights load directly through PyTorch-Wildlife, so existing V5 workflows keep running without changes, while `microsoft/MegaDetector` carries V6 and future development.
 
 
 ## Part of the Biodiversity ecosystem

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,5 @@
 ---
+title: "Install MegaDetector: pip, Conda, and GPU Setup"
 description: "Install MegaDetector via PyTorch-Wildlife for camera-trap detection: pip, conda, and Docker on Windows, macOS, and Linux, with optional CUDA GPU support."
 tags:
   - MegaDetector installation
@@ -11,7 +12,7 @@ tags:
 
 # Installation
 
-MegaDetector is installed as part of the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework.
+MegaDetector is installed as part of the [PyTorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) framework. A single `pip install PytorchWildlife` pulls in the latest MegaDetector V6, and the model weights download automatically the first time you run a detection.
 
 ```bash
 pip install PytorchWildlife

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -1,4 +1,5 @@
 ---
+title: "MegaDetector Model Zoo: V6 Variants, Benchmarks, and Licenses"
 description: "MegaDetector model zoo: all MegaDetectorV6 variants with architectures, parameter counts, animal recall, mAP50, and license options for camera traps."
 tags:
   - MegaDetector
@@ -58,6 +59,14 @@ from PytorchWildlife.models import detection as pw_detection
 model = pw_detection.MegaDetectorV6(version="MDV6-apa-rtdetr-e")
 ```
 
+### YOLOv10 variants (MDV6-yolov10-*)
+
+YOLOv10 covers the broadest range in the zoo. The extra-size `MDV6-yolov10-e` (29.5M parameters) reaches 82.8% animal recall, while the compact `MDV6-yolov10-c` shrinks to 2.3M parameters for laptops and edge devices. Both ship under AGPL-3.0 and are selectable from the `megadetector` CLI.
+
+### RT-DETR variants (MDV6-rtdetr-*)
+
+RT-DETR is where the top accuracy sits. `MDV6-apa-rtdetr-e` records the highest animal recall in the table (82.9%) under an Apache-2.0 license, which suits projects that need permissive terms. A smaller `MDV6-apa-rtdetr-c` and an AGPL `MDV6-rtdetr-c` round out the family.
+
 
 ## Model Licensing
 
@@ -75,7 +84,7 @@ The repository **code** is MIT-licensed independently of the weights. Always con
 > The [`megadetector` CLI](cli.md) selects from the AGPL YOLOv9/YOLOv10/RT-DETR variants via `--model`; the MIT and Apache variants are loaded through the PyTorch-Wildlife Python API.
 
 
-## Performance Benchmarks
+## Performance Benchmarks: GPU and Edge CPU Inference
 
 | Hardware | Model | Approximate Speed |
 | --- | --- | --- |
@@ -85,6 +94,8 @@ The repository **code** is MIT-licensed independently of the weights. Always con
 | Google Colab (free GPU) | Any V6 variant | ~10–50 images/sec |
 
 At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU with the compact model, about 3.9 days. Every V6 variant is faster than V5 (139.9M params).
+
+**Edge and CPU inference:** the compact `MDV6-yolov10-c` (2.3M parameters) is the variant to target for CPU-only and edge hardware. It needs no GPU and runs at roughly 2–5 images/sec on a modern CPU, which is what makes it a fit for field devices like the [SPARROW](https://github.com/microsoft/SPARROW) unit.
 
 
 ## Version History
@@ -102,4 +113,4 @@ At 50 images/sec on a GPU, **one million images takes about 5.5 hours**. On CPU 
 
 For MegaDetectorV5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`).
 
-MegaDetector V1–V5 came from **Dan Morris** at Microsoft; his community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector) is still widely used.
+MegaDetector V1–V5 were originally developed by **Dan Morris** at Microsoft. The V5 weights load directly through PyTorch-Wildlife, so existing V5 pipelines continue to work.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,4 +1,5 @@
 ---
+title: "Browse MegaDetector Documentation by Topic"
 description: "Browse all topics across the MegaDetector documentation."
 ---
 

--- a/docs/training_guide.md
+++ b/docs/training_guide.md
@@ -1,4 +1,5 @@
 ---
+title: "MegaDetector Fine-Tuning Guide: Train Custom V6 Models"
 description: "MegaDetector fine-tuning guide: train custom MegaDetectorV6 detection models (YOLOv9, YOLOv10, RT-DETR) on your own camera-trap wildlife data."
 tags:
   - MegaDetector fine-tuning
@@ -44,7 +45,7 @@ conda env create -f environment.yaml
 conda activate megadetector-finetuning
 ```
 
-## Data Preparation
+## Data Preparation: Custom Camera-Trap Datasets
 
 ### Data Structure
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,3 +113,7 @@ plugins:
   - search
   - meta
   - tags
+  - git-revision-date-localized:
+      type: date
+      enable_creation_date: true
+      fallback_to_build_date: true

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -89,10 +89,10 @@
       },
       {
         "@type": "Question",
-        "name": "What is the difference between MegaDetectorV5 and MegaDetectorV6?",
+        "name": "MegaDetector V6 vs V5: what's the difference?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetectorV5 uses the YOLOv5 architecture with 139.9M parameters. MegaDetectorV6 uses modern architectures (YOLOv9, YOLOv10, RT-DETR) with compact variants as small as 2.3M parameters, about 2% of V5. Both are MIT-licensed. Use MegaDetectorV6 for new projects; MegaDetectorV5 remains available and is actively maintained by Dan Morris."
+          "text": "MegaDetectorV5 uses the YOLOv5 architecture with 139.9M parameters. MegaDetectorV6 uses modern architectures (YOLOv9, YOLOv10, RT-DETR) with compact variants as small as 2.3M parameters, about 2% of V5. Both are MIT-licensed. Use MegaDetectorV6 for new projects; MegaDetectorV5 weights remain available on the archive branch for projects already built around them."
         }
       },
       {
@@ -145,10 +145,26 @@
       },
       {
         "@type": "Question",
-        "name": "What is Dan Morris's fork?",
+        "name": "How do I filter blank camera-trap images?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Dan Morris built MegaDetector V1–V5 while at Microsoft and now runs a community fork at agentmorris/MegaDetector. It bundles years of helper scripts, batch-processing tools, and documentation, and stays useful for V5 weights or the original run_detector_batch.py workflow. The microsoft/MegaDetector repository carries MegaDetectorV6 and future development. Both projects coexist and serve the community."
+          "text": "Run MegaDetector across your image folder and keep only the frames that have an animal, person, or vehicle detection above your confidence threshold. Everything below the threshold is a blank you can set aside. Since most camera-trap datasets are mostly empty, this one pass clears the bulk of the review queue before any human looks at an image. See the Camera-Trap AI page for the full blank-filtering workflow."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What confidence threshold should I use?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A starting value of 0.15–0.3 on the animal category works for most datasets. That range favors recall, so you keep most true animals while accepting some false positives on moving vegetation and lighting artifacts. Raise it when a clean set matters more than catching every animal; lower it when a missed animal costs more than a few extra frames to review. When you move to a new deployment, check recall against a small labeled set first."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I fine-tune MegaDetector on my own data?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. MegaDetectorV6 ships a training pipeline for fine-tuning the YOLOv9, YOLOv10, and RT-DETR variants on your own labeled camera-trap images, which helps when your species or habitats are thin in the base model. The fine-tuning guide covers the data layout, the configuration file, and the megadetector train command from start to finish."
         }
       },
       {
@@ -156,7 +172,7 @@
         "name": "Where are the V5 weights?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MegaDetectorV5 weights are available on the archive branch of the microsoft/Biodiversity repository (formerly microsoft/CameraTraps). Dan Morris's fork at agentmorris/MegaDetector also hosts V5 and provides extensive tooling around it."
+          "text": "MegaDetectorV5 weights are available on the archive branch of the microsoft/Biodiversity repository (formerly microsoft/CameraTraps). They load directly through PyTorch-Wildlife, so existing V5 workflows keep running without changes."
         }
       },
       {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ mkdocs
 mkdocs-get-deps
 mkdocs-material
 mkdocs-material-extensions
+mkdocs-git-revision-date-localized-plugin
 pymdown-extensions


### PR DESCRIPTION
Next-round on-page SEO for the docs site, building on the work merged in #16 through #25. Cut-and-dry docs revisions bundled into one PR for a single review pass. `mkdocs build --strict` passes; the FAQPage JSON-LD stays in sync with the visible FAQ.

## 1. Long-tail keyword content
Targets pending long-tail queries from the keyword review with answer-first sections, no padding.
- **faq.md:** new questions for filtering blank camera-trap images, fine-tuning on your own data, and choosing a confidence threshold; renamed the V5/V6 question to "MegaDetector V6 vs V5".
- **model_zoo.md:** added YOLOv10 and RT-DETR variant sections; renamed the benchmarks heading to cover GPU and edge CPU inference and added an edge/CPU note.
- **camera-trap-ai.md:** added "Filtering blank camera-trap images" and "Species classification with MegaDetector" subsections.
- **installation.md:** added a pip-install lede. **training_guide.md:** clarified the data-preparation heading.
- **overrides/main.html:** updated the FAQPage structured data so it mirrors the visible FAQ (added the three new Q&As, removed the retired one).

## 2. Fork-link minimization
- Removed the `agentmorris/MegaDetector` community-fork links from README, index, faq, and model_zoo, pointing V5 users to the Microsoft archive branch and PyTorch-Wildlife instead.
- Citation author names and the `microsoft/Biodiversity` archive-branch link are retained.

## 3. Front-matter titles
- Added a unique front-matter `title` to the 9 docs that previously relied on the H1 fallback, so every page now sets an explicit title. Descriptions were already present.

## 4. Last-updated dates
- Added the `git-revision-date-localized` plugin (`mkdocs.yml`, `requirements.txt`) and set `fetch-depth: 0` on the docs-deploy checkout so the plugin can read commit history and render accurate last-updated dates.

## Verification
- `mkdocs build --strict` passes with the new plugin; last-updated dates render on built pages.
- FAQPage JSON-LD parses and matches the visible FAQ (16 Q&As).
- Prose checked for em-dashes and AI-slop tells (none introduced); positioning, threshold wording, and the "animals, people, and vehicles" framing are unchanged.