### PR TITLE
fix(docs): render GitHub-style callouts, lead homepage with value proposition

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,12 @@ tags:
 
 # MegaDetector
 
-> [!TIP]
-> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella, the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
-
 **Built by the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good), MegaDetector is an open-source model that locates animals, people, and vehicles in camera-trap images.** A typical camera deployment produces millions of frames, most of them empty. MegaDetector boxes whatever it finds and scores each box, so researchers can clear the blanks automatically and spend their time on science rather than sorting images.
 
 MegaDetector is an **animal detector**, not a species classifier. For species recognition, pair MegaDetector with a downstream classifier (see [Species classification](#species-classification) below). It is free and open-source under the [MIT License](https://github.com/microsoft/MegaDetector/blob/main/LICENSE), and runs in more than 80 conservation programs worldwide.
+
+> [!TIP]
+> MegaDetector is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella, the hub for all AI for Good Lab wildlife tools. The full PyTorch-Wildlife framework and model zoo live at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife).
 
 This page is the practical user guide for the current release, **MegaDetectorV6**. If you want a one-screen reference, jump to [Quick start](#quick-start); if you're evaluating whether MegaDetector fits your project, the [FAQ](faq.md) answers the most common questions.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ markdown_extensions:
       pygments_lang_class: true
 
 plugins:
+  - callouts
   - search
   - meta
   - tags

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ mkdocs
 mkdocs-get-deps
 mkdocs-material
 mkdocs-material-extensions
+mkdocs-callouts
 mkdocs-git-revision-date-localized-plugin
 pymdown-extensions


### PR DESCRIPTION
## Problem
The docs site uses GitHub-style `> [!TIP]` / `> [!NOTE]` callout syntax (8 occurrences across `docs/`). GitHub renders these natively, but **MkDocs Material does not**, so the literal string `[!TIP]` was showing on the rendered pages and, worse, leaking into search and AI-summary source snippets. On the homepage the broken callout sat directly after the H1, so Google's AI-overview source card led with `MegaDetector[!TIP] MegaDetector is part of the microsoft/Biodiversity umbrella…` instead of the actual description.

## Fix
- **Add the `mkdocs-callouts` plugin** (`mkdocs.yml`, `requirements.txt`). It converts `> [!TIP]` blocks to Material admonitions at build time, so one callout syntax works in both the README (GitHub) and the docs site (Material). All 8 callouts now render correctly with no source rewrites needed.
- **Reorder the homepage** so the value-proposition sentence ("Built by the Microsoft AI for Good Lab, MegaDetector is an open-source model that locates animals, people, and vehicles…") is the first content after the H1. The Biodiversity-umbrella tip now follows the intro, so search and AI summaries pull the value prop as the snippet lead.

## Verification
- `mkdocs build --strict` passes.
- Zero literal `[!TIP]` / `[!NOTE]` strings remain in the built site (was 8+).
- The homepage admonition renders, and the first scraped text is now the value-proposition sentence.

## Note on merge order
This branches from `main`, independent of the in-review SEO PR #26. Both touch the `plugins:` block in `mkdocs.yml` and `requirements.txt`, so whichever merges second may need a trivial rebase (each just adds a distinct plugin line).