### PR TITLE
fix: repoint dead full-list links to the Biodiversity collaborators page

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ MegaDetector is the entry point for most users. SPARROW Studio is the full platf
 
 ## Organizations Using MegaDetector
 
-MegaDetector is used by more than 80 organizations worldwide, including government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [PyTorch-Wildlife list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector):
+MegaDetector is used by more than 80 organizations worldwide, including government agencies, universities, NGOs, museums, and technology platforms. A selection of adopters named in the [Biodiversity collaborators list](https://microsoft.github.io/Biodiversity/collaborators/):
 
 <!-- ATTESTED IN THIS REPO -->
 **Government**: Arizona DEQ, Idaho Fish & Game, Oregon DFW, Michigan DNR, Parks Canada (Banff), U.S. Fish & Wildlife Service (multiple refuges), National Park Service, Canadian Wildlife Service
@@ -291,7 +291,7 @@ MegaDetector is used by more than 80 organizations worldwide, including governme
 
 **Platforms**: TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network, OCAPI, WildePod
 
-See the [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) in the PyTorch-Wildlife repository.
+See the [full list](https://microsoft.github.io/Biodiversity/collaborators/) on the Biodiversity documentation site.
 <!-- /ATTESTED -->
 <!-- APPROVED-EXTERNAL: append reviewed organizations below this line -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,7 +174,7 @@ MegaDetector is used by more than 80 organizations worldwide, including governme
 - **Museums & zoos**, American Museum of Natural History, Smithsonian, San Diego Zoo Wildlife Alliance, Taronga Conservation Society
 - **Platforms**, TrapTagger, WildTrax, Camelot, Animl, Wildlife Observer Network
 
-The [full list](https://github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector) lives in the PyTorch-Wildlife repository.
+The [full list](https://microsoft.github.io/Biodiversity/collaborators/) lives on the Biodiversity documentation site.
 
 
 ## MegaDetectorV5 and earlier


### PR DESCRIPTION
## What
The README and docs homepage linked the adopter "full list" to `github.com/microsoft/Pytorch-Wildlife#who-uses-megadetector`, but that section no longer exists in the PyTorch-Wildlife README. The canonical list now lives on the Biodiversity documentation site.

Repoints all 3 in-repo occurrences to `https://microsoft.github.io/Biodiversity/collaborators/`:
- README.md (inline adopter-list link + "See the full list")
- docs/index.md ("Who uses MegaDetector?" section)

The attested category excerpt and the APPROVED-EXTERNAL marker are left intact.

## Why
The old anchor is dead, so readers hit a non-existent section. Pairs with microsoft/Biodiversity#652, which verifies and enriches that canonical page.

## Verification
- `grep` confirms zero remaining `who-uses-megadetector` references and 3 new links.
- `mkdocs build` renders the homepage with the corrected link.