### PR TITLE
ci: deploy docs when overrides/ changes + add manual trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,8 +6,10 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'overrides/**'
       - 'mkdocs.yml'
       - 'requirements.txt'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Problem
The `Deploy MkDocs site` workflow triggers on pushes to `main` that touch `docs/**`, `mkdocs.yml`, or `requirements.txt`. The theme override `overrides/main.html` — which holds the JSON-LD, Open Graph, and social-card meta — is **not** watched. So an overrides-only SEO PR merges to main but never triggers a deploy, and the change never goes live.

This already happened: PR #29 (JSON-LD `@graph` tightening) merged but did not deploy, because it touched only `overrides/main.html`.

## Fix
- Add `overrides/**` to the push path filter, so theme/SEO override changes deploy.
- Add a `workflow_dispatch:` trigger, so a stranded change (like #29) can be redeployed manually without an empty commit.

## After merge
Trigger `Deploy MkDocs site` via workflow_dispatch once to publish the already-merged #29.