### PR TITLE
chore: use 'AI-enabled' instead of 'AI-powered' in package text

### DIFF
--- a/src/megadetector_ai/__init__.py
+++ b/src/megadetector_ai/__init__.py
@@ -1,5 +1,5 @@
 """
-MegaDetector: AI-powered wildlife detection for camera trap images.
+MegaDetector: AI-enabled wildlife detection for camera trap images.
 
 This package provides a simplified interface to MegaDetector models
 via PyTorch Wildlife. MegaDetector detects animals, people, and vehicles

--- a/src/megadetector_ai/cli.py
+++ b/src/megadetector_ai/cli.py
@@ -150,7 +150,7 @@ def inference(args):
 def main():
     parser = argparse.ArgumentParser(
         prog="megadetector",
-        description="MegaDetector: AI-powered wildlife detection for camera trap images",
+        description="MegaDetector: AI-enabled wildlife detection for camera trap images",
     )
     subparsers = parser.add_subparsers(dest="command")
 

--- a/src/megadetector_core/__init__.py
+++ b/src/megadetector_core/__init__.py
@@ -1,5 +1,5 @@
 """
-MegaDetector: AI-powered wildlife detection for camera trap images.
+MegaDetector: AI-enabled wildlife detection for camera trap images.
 
 This package provides a simplified interface to MegaDetector models
 via PyTorch Wildlife. MegaDetector detects animals, people, and vehicles

--- a/src/megadetector_core/cli.py
+++ b/src/megadetector_core/cli.py
@@ -171,7 +171,7 @@ def inference(args):
 def main():
     parser = argparse.ArgumentParser(
         prog="megadetector",
-        description="MegaDetector: AI-powered wildlife detection for camera trap images",
+        description="MegaDetector: AI-enabled wildlife detection for camera trap images",
     )
     subparsers = parser.add_subparsers(dest="command")
 


### PR DESCRIPTION
## Why

Microsoft brand guideline: products are described as **AI-enabled**, not "AI-powered".

## What

Updates the four package strings that used "AI-powered":

- `src/megadetector_core/__init__.py` (module docstring)
- `src/megadetector_core/cli.py` (argparse `description`)
- `src/megadetector_ai/__init__.py` (module docstring)
- `src/megadetector_ai/cli.py` (argparse `description`)

Text-only; no behavior change. The docs site was already clean (it uses "AI-enabled"). Note `megadetector_ai` is the duplicate package tracked in #22; updated here for consistency in case it lingers.

Opened as a draft; not requesting review yet.